### PR TITLE
Fix invalid local windows path when using GDB over SSH

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -5,6 +5,7 @@ import { MINode } from './backend/mi_parse'
 import { expandValue, isExpandable } from './backend/gdb_expansion'
 import { MI2 } from './backend/mi2/mi2'
 import { posix } from "path"
+import * as systemPath from "path"
 
 let resolve = posix.resolve;
 let relative = posix.relative;
@@ -197,7 +198,7 @@ class MI2DebugSession extends DebugSession {
 				let file = element.file;
 				if (this.isSSH) {
 					file = relative(this.switchCWD.replace(/\\/g, "/"), file.replace(/\\/g, "/"));
-					file = resolve(this.trimCWD.replace(/\\/g, "/"), file.replace(/\\/g, "/"));
+					file = systemPath.resolve(this.trimCWD.replace(/\\/g, "/"), file.replace(/\\/g, "/"));
 				}
 				ret.push(new StackFrame(element.level, element.function + "@" + element.address, new Source(element.fileName, file), element.line, 0));
 			});


### PR DESCRIPTION
Because of the global POSIX configuration for path-related processing, the
local absolute paths of files with a breakpoint were not translated
correctly.

This fix forces the use of the default NodeJS path.resolve instead of the
global POSIX override.

This PR should fix the issues mentioned in #11 