### PR TITLE
Force the use of tabs within .vscode/settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+	"editor.insertSpaces": false,
 	"files.exclude": {
 		"out": false // set this to true to hide the "out" folder with the compiled JS files
 	},


### PR DESCRIPTION
As some developers might use spaces as a global setting.