### PR TITLE
Fix non-working Fortran breakpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 						"cpp",
 						"d",
 						"objective-c",
-						"fortan",
+						"fortran",
+						"fortran-modern",
 						"pascal",
 						"ada"
 					]


### PR DESCRIPTION
Might still require https://github.com/Gimly/vscode-fortran for files to be recognized with the correct IDs.