### PR TITLE
Add the -f flag to break-insert

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -344,7 +344,7 @@ export class MI2 extends EventEmitter implements IBackend {
 		return new Promise((resolve, reject) => {
 			if (this.breakpoints.has(breakpoint))
 				return resolve(false);
-			this.sendCommand("break-insert " + breakpoint.file + ":" + breakpoint.line).then((result) => {
+			this.sendCommand("break-insert -f " + breakpoint.file + ":" + breakpoint.line).then((result) => {
 				if (result.resultRecords.resultClass == "done") {
 					let bkptNum = parseInt(result.result("bkpt.number"));
 					let newBrk = {


### PR DESCRIPTION
To also support shared libraries which are loaded after the breakpoint
insertion.

Additional info about the issue can be seen [here (NetBeans bugtracker)](https://netbeans.org/bugzilla/show_bug.cgi?id=144897).