### PR TITLE
Added "objectpascal" to list of breakpoint enabled languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 						"fortran-modern",
 						"rust",
 						"pascal",
+						"objectpascal",
 						"ada",
 						"nim"
 					]


### PR DESCRIPTION
"objectpascal" is currently missing so it is impossible to use the debugger extension in conjunction with OmniPascal