### PR TITLE
Enable breakpoints for x86(-64) and ARM assembly when using GDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
 						"pascal",
 						"objectpascal",
 						"ada",
-						"nim"
+						"nim",
+						"arm",
+						"asm"
 					]
 				},
 				"configurationAttributes": {


### PR DESCRIPTION
Adds support for setting breakpoint in x86/x86_64 and ARM assembly files. The language ID's are from the [`language-x86-64-assembly`](https://marketplace.visualstudio.com/items?itemName=13xforever.language-x86-64-assembly) and [`arm`](https://marketplace.visualstudio.com/items?itemName=dan-c-underwood.arm) packages, respectively.