### PR TITLE
Quote input when adding breakpoint

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -468,7 +468,7 @@ export class MI2 extends EventEmitter implements IBackend {
 			if (breakpoint.raw)
 				location = '"' + escape(breakpoint.raw) + '"';
 			else
-				location = '"' + breakpoint.file + ":" + breakpoint.line + '"';
+				location = '"' + escape(breakpoint.file) + ":" + breakpoint.line + '"';
 			this.sendCommand("break-insert -f " + location).then((result) => {
 				if (result.resultRecords.resultClass == "done") {
 					let bkptNum = parseInt(result.result("bkpt.number"));

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -468,7 +468,7 @@ export class MI2 extends EventEmitter implements IBackend {
 			if (breakpoint.raw)
 				location = '"' + escape(breakpoint.raw) + '"';
 			else
-				location = breakpoint.file + ":" + breakpoint.line;
+				location = '"' + breakpoint.file + ":" + breakpoint.line + '"';
 			this.sendCommand("break-insert -f " + location).then((result) => {
 				if (result.resultRecords.resultClass == "done") {
 					let bkptNum = parseInt(result.result("bkpt.number"));


### PR DESCRIPTION
File path and line number are now double quoted when specified explicitly. Before only when using raw input was it double quoted.

Possibly fixes #80 and maybe others, however I was experiencing a problem with setting breakpoints on linux.

Also untested, would be great if a maintainer could - I don't have time to set up the development environment