### PR TITLE
Add config option to pass arguments to GDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
-
+language: node_js
+node_js:
+  - stable
 os:
   - osx
   - linux

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
 								"description": "Path to the gdb executable or the command if in PATH",
 								"default": "gdb"
 							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to GDB",
+								"default": []
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all GDB calls to the console",
@@ -201,6 +206,11 @@
 								"description": "Path to the gdb executable or the command if in PATH",
 								"default": "gdb"
 							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to GDB",
+								"default": []
+							},
 							"cwd": {
 								"type": "string",
 								"description": "Path of project",
@@ -283,6 +293,11 @@
 								"type": "string",
 								"description": "Path to the lldb-mi executable or the command if in PATH",
 								"default": "lldb-mi"
+							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to LLDB",
+								"default": []
 							},
 							"printCalls": {
 								"type": "boolean",
@@ -389,6 +404,11 @@
 								"description": "Path to the lldb-mi executable or the command if in PATH",
 								"default": "lldb-mi"
 							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to LLDB",
+								"default": []
+							},
 							"cwd": {
 								"type": "string",
 								"description": "Path of project",
@@ -450,6 +470,11 @@
 								"description": "Path to the mago-mi executable or the command if in PATH",
 								"default": "mago-mi"
 							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to mago",
+								"default": []
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all mago calls to the console",
@@ -494,6 +519,11 @@
 								"type": "string",
 								"description": "Path to the mago-mi executable or the command if in PATH",
 								"default": "mago-mi"
+							},
+							"debugger_args": {
+								"type": "array",
+								"description": "Additional arguments to pass to mago",
+								"default": []
 							},
 							"cwd": {
 								"type": "string",

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -27,7 +27,7 @@ function couldBeOutput(line: string) {
 const trace = false;
 
 export class MI2 extends EventEmitter implements IBackend {
-	constructor(public application: string, public preargs: string[]) {
+	constructor(public application: string, public preargs: string[], public extraargs: string[]) {
 		super();
 	}
 
@@ -36,7 +36,8 @@ export class MI2 extends EventEmitter implements IBackend {
 			target = nativePath.join(cwd, target);
 		return new Promise((resolve, reject) => {
 			this.isSSH = false;
-			this.process = ChildProcess.spawn(this.application, this.preargs, { cwd: cwd });
+			let args = this.preargs.concat(this.extraargs || []);
+			this.process = ChildProcess.spawn(this.application, args, { cwd: cwd });
 			this.process.stdout.on("data", this.stdout.bind(this));
 			this.process.stderr.on("data", this.stderr.bind(this));
 			this.process.on("exit", (() => { this.emit("quit"); }).bind(this));

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -8,6 +8,7 @@ export interface LaunchRequestArguments {
 	cwd: string;
 	target: string;
 	gdbpath: string;
+	debugger_args: string[];
 	arguments: string;
 	terminal: string;
 	autorun: string[];
@@ -20,6 +21,7 @@ export interface AttachRequestArguments {
 	cwd: string;
 	target: string;
 	gdbpath: string;
+	debugger_args: string[];
 	executable: string;
 	remote: boolean;
 	autorun: string[];
@@ -40,7 +42,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"]);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -109,7 +111,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"]);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = !args.remote;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -8,6 +8,7 @@ export interface LaunchRequestArguments {
 	cwd: string;
 	target: string;
 	lldbmipath: string;
+	debugger_args: string[];
 	arguments: string;
 	autorun: string[];
 	ssh: SSHArguments;
@@ -19,6 +20,7 @@ export interface AttachRequestArguments {
 	cwd: string;
 	target: string;
 	lldbmipath: string;
+	debugger_args: string[];
 	executable: string;
 	autorun: string[];
 	printCalls: boolean;
@@ -36,7 +38,7 @@ class LLDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", []);
+		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -97,7 +99,7 @@ class LLDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", []);
+		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -8,6 +8,7 @@ export interface LaunchRequestArguments {
 	cwd: string;
 	target: string;
 	magomipath: string;
+	debugger_args: string[];
 	arguments: string;
 	autorun: string[];
 	printCalls: boolean;
@@ -18,6 +19,7 @@ export interface AttachRequestArguments {
 	cwd: string;
 	target: string;
 	magomipath: string;
+	debugger_args: string[];
 	executable: string;
 	autorun: string[];
 	printCalls: boolean;
@@ -43,7 +45,7 @@ class MagoDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", ["-q"]);
+		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", ["-q"], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -72,7 +74,7 @@ class MagoDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", []);
+		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", [], args.debugger_args);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;


### PR DESCRIPTION
Hey,
this PR adds a config option that can be used to pass arguments to GDB.
I'm using it to disable my `.gdbinit` file by setting `gdbargs` to `["-nx", "-x ~/.custom_gdbinit"]` because my `.gdbinit` expects a real tty.
If you think a generic `debugger_args` option shared between all backends would be better though I'm open to push changes.