### PR TITLE
Gdb var objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,16 @@
 								"description": "Additional arguments to pass to GDB",
 								"default": []
 							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all GDB calls to the console",
@@ -191,6 +201,16 @@
 								"type": "boolean",
 								"description": "If true this will connect to a gdbserver instead of attaching to a PID",
 								"default": false
+							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
 							},
 							"printCalls": {
 								"type": "boolean",
@@ -466,6 +486,16 @@
 								"description": "Additional arguments to pass to LLDB",
 								"default": []
 							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all lldb calls to the console",
@@ -551,6 +581,16 @@
 							"target": {
 								"type": "string",
 								"description": "PID of running program or program name"
+							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
 							},
 							"printCalls": {
 								"type": "boolean",
@@ -713,6 +753,16 @@
 								"description": "Additional arguments to pass to mago",
 								"default": []
 							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all mago calls to the console",
@@ -738,6 +788,16 @@
 							"target": {
 								"type": "string",
 								"description": "PID of running program or program name"
+							},
+							"valuesFormatting": {
+								"type": "string",
+								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
+								"default": "parseText",
+								"enum": [
+									"disabled",
+									"parseText",
+									"prettyPrinters"
+								]
 							},
 							"printCalls": {
 								"type": "boolean",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,3 +1,6 @@
+import { MINode } from "./mi_parse";
+import { DebugProtocol } from "vscode-debugprotocol/lib/debugProtocol";
+
 export interface Breakpoint {
 	file?: string;
 	line?: number;
@@ -59,4 +62,62 @@ export interface IBackend {
 	isReady(): boolean;
 	changeVariable(name: string, rawValue: string): Thenable<any>;
 	examineMemory(from: number, to: number): Thenable<any>;
+}
+
+export class VariableObject {
+	name: string;
+	exp: string;
+	numchild: number;
+	type: string;
+	value: string;
+	threadId: string;
+	frozen: boolean;
+	dynamic: boolean;
+	displayhint: string;
+	has_more: boolean;
+	id: number;
+	constructor(node: any) {
+		this.name = MINode.valueOf(node, "name");
+		this.exp = MINode.valueOf(node, "exp");
+		this.numchild = parseInt(MINode.valueOf(node, "numchild"));
+		this.type = MINode.valueOf(node, "type");
+		this.value = MINode.valueOf(node, "value");
+		this.threadId = MINode.valueOf(node, "thread-id");
+		this.frozen = !!MINode.valueOf(node, "frozen");
+		this.dynamic = !!MINode.valueOf(node, "dynamic");
+		this.displayhint = MINode.valueOf(node, "displayhint");
+		// TODO: use has_more when it's > 0
+		this.has_more = !!MINode.valueOf(node, "has_more");
+	}
+
+	public applyChanges(node: MINode) {
+		this.value = MINode.valueOf(node, "value");
+		if (!!MINode.valueOf(node, "type_changed")) {
+			this.type = MINode.valueOf(node, "new_type");
+		}
+		this.dynamic = !!MINode.valueOf(node, "dynamic");
+		this.displayhint = MINode.valueOf(node, "displayhint");
+		this.has_more = !!MINode.valueOf(node, "has_more");
+	}
+
+	public isCompound(): boolean {
+		return this.numchild > 0 ||
+			this.value === "{...}" ||
+			(this.dynamic && (this.displayhint === "array" || this.displayhint === "map"));
+	}
+
+	public toProtocolVariable(): DebugProtocol.Variable {
+		let res: DebugProtocol.Variable = {
+			name: this.exp,
+			evaluateName: this.name,
+			value: (this.value === void 0) ? "<unknown>" : this.value,
+			type: this.type,
+			// kind: this.displayhint,
+			variablesReference: this.id
+		};
+		if (this.displayhint) {
+			res.kind = this.displayhint;
+		}
+		return res;
+	}
 }

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -1,6 +1,8 @@
 import { MINode } from "./mi_parse";
 import { DebugProtocol } from "vscode-debugprotocol/lib/debugProtocol";
 
+export type ValuesFormattingMode = "disabled" | "parseText" | "prettyPrinters";
+
 export interface Breakpoint {
 	file?: string;
 	line?: number;

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -196,9 +196,9 @@ export class MI2 extends EventEmitter implements IBackend {
 		];
 		if (!attach)
 			cmds.push(this.sendCommand("file-exec-and-symbols \"" + escape(target) + "\""));
+		if (this.prettyPrint)
+			cmds.push(this.sendCommand("enable-pretty-printing"));
 
-		// TODO: add extension parameter for enabling/disabling pretty printers
-		cmds.push(this.sendCommand("enable-pretty-printing"));
 		return cmds;
 	}
 
@@ -668,7 +668,7 @@ export class MI2 extends EventEmitter implements IBackend {
 		return new VariableObject(res.result(""));
 	}
 
-	async varEvalExpression(name: string): Promise < MINode > {
+	async varEvalExpression(name: string): Promise<MINode> {
 		if (trace)
 			this.log("stderr", "varEvalExpression");
 		return this.sendCommand(`var-evaluate-expression ${name}`);
@@ -746,6 +746,7 @@ export class MI2 extends EventEmitter implements IBackend {
 		return this.isSSH ? this.sshReady : !!this.process;
 	}
 
+	prettyPrint: boolean = true;
 	printCalls: boolean;
 	debugOutput: boolean;
 	public procEnv: any;

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -690,6 +690,12 @@ export class MI2 extends EventEmitter implements IBackend {
 		return this.sendCommand(`var-update --all-values ${name}`)
 	}
 
+	async varAssign(name: string, rawValue: string): Promise<MINode> {
+		if (trace)
+			this.log("stderr", "varAssign");
+		return this.sendCommand(`var-assign ${name} ${rawValue}`);
+	}
+
 	logNoNewLine(type: string, msg: string) {
 		this.emit("msg", type, msg);
 	}

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -196,6 +196,9 @@ export class MI2 extends EventEmitter implements IBackend {
 		];
 		if (!attach)
 			cmds.push(this.sendCommand("file-exec-and-symbols \"" + escape(target) + "\""));
+
+		// TODO: add extension parameter for enabling/disabling pretty printers
+		cmds.push(this.sendCommand("enable-pretty-printing"));
 		return cmds;
 	}
 
@@ -656,6 +659,19 @@ export class MI2 extends EventEmitter implements IBackend {
 				resolve(result);
 			}, reject);
 		});
+	}
+
+	async varCreate(expression: string): Promise<MINode> {
+		if (trace)
+			this.log("stderr", "varCreate");
+		return this.sendCommand(`var-create - * "${expression}"`);
+	}
+
+	async varListChildren(name: string): Promise<MINode> {
+		if (trace)
+			this.log("stderr", "varListChildren");
+		//TODO: add `from` and `to` arguments
+		return this.sendCommand(`var-list-children --simple-values ${name}`);
 	}
 
 	logNoNewLine(type: string, msg: string) {

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -617,27 +617,25 @@ export class MI2 extends EventEmitter implements IBackend {
 		});
 	}
 
-	getStackVariables(thread: number, frame: number): Thenable<Variable[]> {
+	async getStackVariables(thread: number, frame: number): Promise<Variable[]> {
 		if (trace)
 			this.log("stderr", "getStackVariables");
-		return new Promise((resolve, reject) => {
-			this.sendCommand("stack-list-variables --thread " + thread + " --frame " + frame + " --simple-values").then((result) => {
-				let variables = result.result("variables");
-				let ret: Variable[] = [];
-				variables.forEach(element => {
-					const key = MINode.valueOf(element, "name");
-					const value = MINode.valueOf(element, "value");
-					const type = MINode.valueOf(element, "type");
-					ret.push({
-						name: key,
-						valueStr: value,
-						type: type,
-						raw: element
-					});
-				});
-				resolve(ret);
-			}, reject);
-		});
+
+		const result = await this.sendCommand(`stack-list-variables --thread ${thread} --frame ${frame} --simple-values`);
+		const variables = result.result("variables");
+		let ret: Variable[] = [];
+		for (const element of variables) {
+			const key = MINode.valueOf(element, "name");
+			const value = MINode.valueOf(element, "value");
+			const type = MINode.valueOf(element, "type");
+			ret.push({
+				name: key,
+				valueStr: value,
+				type: type,
+				raw: element
+			});
+		}
+		return ret;
 	}
 
 	examineMemory(from: number, length: number): Thenable<any> {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -2,7 +2,7 @@ import { MI2DebugSession } from './mibase';
 import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { MI2 } from "./backend/mi2/mi2";
-import { SSHArguments } from './backend/backend';
+import { SSHArguments, ValuesFormattingMode } from './backend/backend';
 
 export interface LaunchRequestArguments {
 	cwd: string;
@@ -14,6 +14,7 @@ export interface LaunchRequestArguments {
 	terminal: string;
 	autorun: string[];
 	ssh: SSHArguments;
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -28,6 +29,7 @@ export interface AttachRequestArguments {
 	remote: boolean;
 	autorun: string[];
 	ssh: SSHArguments;
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -54,6 +56,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.started = false;
 		this.crashed = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		if (args.ssh !== undefined) {
@@ -121,6 +124,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.needContinue = true;
 		this.isSSH = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		if (args.ssh !== undefined) {

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -2,7 +2,7 @@ import { MI2DebugSession } from './mibase';
 import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { MI2_LLDB } from "./backend/mi2/mi2lldb";
-import { SSHArguments } from './backend/backend';
+import { SSHArguments, ValuesFormattingMode } from './backend/backend';
 
 export interface LaunchRequestArguments {
 	cwd: string;
@@ -13,6 +13,7 @@ export interface LaunchRequestArguments {
 	arguments: string;
 	autorun: string[];
 	ssh: SSHArguments;
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -25,6 +26,7 @@ export interface AttachRequestArguments {
 	debugger_args: string[];
 	executable: string;
 	autorun: string[];
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -49,6 +51,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.started = false;
 		this.crashed = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		if (args.ssh !== undefined) {
@@ -108,6 +111,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.needContinue = true;
 		this.isSSH = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.miDebugger.attach(args.cwd, args.executable, args.target).then(() => {

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -2,7 +2,7 @@ import { MI2DebugSession } from './mibase';
 import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { MI2_Mago } from "./backend/mi2/mi2mago";
-import { SSHArguments } from './backend/backend';
+import { SSHArguments, ValuesFormattingMode } from './backend/backend';
 
 export interface LaunchRequestArguments {
 	cwd: string;
@@ -12,6 +12,7 @@ export interface LaunchRequestArguments {
 	debugger_args: string[];
 	arguments: string;
 	autorun: string[];
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -24,6 +25,7 @@ export interface AttachRequestArguments {
 	debugger_args: string[];
 	executable: string;
 	autorun: string[];
+	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -56,6 +58,7 @@ class MagoDebugSession extends MI2DebugSession {
 		this.started = false;
 		this.crashed = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.miDebugger.load(args.cwd, args.target, args.arguments, undefined).then(() => {
@@ -83,6 +86,7 @@ class MagoDebugSession extends MI2DebugSession {
 		this.needContinue = true;
 		this.isSSH = false;
 		this.debugReady = false;
+		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.miDebugger.attach(args.cwd, args.executable, args.target).then(() => {


### PR DESCRIPTION
Replace own value parser with [GDB's variable objects](https://sourceware.org/gdb/onlinedocs/gdb/GDB_002fMI-Variable-Objects.html) interface.
This improves variables view and allows to show values from custom pretty-printers loaded into GDB.

| |Before|After|
|---|---|---|
|C++|![cpp_before](https://cloud.githubusercontent.com/assets/1297574/26277555/bc921592-3d92-11e7-8318-fdd7021e9906.png)|![cpp_after](https://cloud.githubusercontent.com/assets/1297574/26277560/cb9d2522-3d92-11e7-9e51-03dd25e7d5c1.png)|
|Rust|![rust_before](https://cloud.githubusercontent.com/assets/1297574/26277569/f12b94e0-3d92-11e7-8d6a-dda1b03b27b5.png)|![rust_after](https://cloud.githubusercontent.com/assets/1297574/26277579/36d36d92-3d93-11e7-8ca7-2245e9c7c4e0.png)|

Tested with `vscode-1.12.2` and `GDB-7.12` on Gentoo Linux