### PR TITLE
add option to use ssh agent for authentication

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,11 @@
 										"type": "string",
 										"description": "Absolute path to private key"
 									},
+									"useAgent": {
+										"type": "boolean",
+										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
+										"default": false
+									},
 									"forwardX11": {
 										"type": "boolean",
 										"description": "If true, the server will redirect x11 to the local host",
@@ -286,6 +291,11 @@
 									"keyfile": {
 										"type": "string",
 										"description": "Absolute path to private key"
+									},
+									"useAgent": {
+										"type": "boolean",
+										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
+										"default": false
 									},
 									"forwardX11": {
 										"type": "boolean",
@@ -546,6 +556,11 @@
 									"keyfile": {
 										"type": "string",
 										"description": "Absolute path to private key"
+									},
+									"useAgent": {
+										"type": "boolean",
+										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
+										"default": false
 									},
 									"forwardX11": {
 										"type": "boolean",

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -38,6 +38,7 @@ export interface SSHArguments {
 	host: string;
 	keyfile: string;
 	password: string;
+	useAgent: boolean;
 	cwd: string;
 	port: number;
 	user: string;

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -121,7 +121,9 @@ export class MI2 extends EventEmitter implements IBackend {
 				username: args.user
 			};
 
-			if (args.keyfile) {
+			if (args.useAgent) {
+				connectionArgs.agent = process.env.SSH_AUTH_SOCK;
+			} else if (args.keyfile) {
 				if (require("fs").existsSync(args.keyfile))
 					connectionArgs.privateKey = require("fs").readFileSync(args.keyfile);
 				else {


### PR DESCRIPTION
Added an option "useAgent" to the "ssh" launch arguments. When this boolean is set to true, it automatically uses the active ssh agent (via SSH_AUTH_SOCK environment variable) for authentication  instead of the other options: "password" or "keyfile".

This should also solve the problem of trying to use a private ssh keyfile that is protected by a passphrase. With this approach the agent will automatically use the default ssh key and lookup the passphrase in the keychain (when it is stored there), this prevents the unsafe requirement of specifying the ssh password or passphrase as plane text in the launch.json file. #134 

(Only tested on Mac OSX 10.13) 