### PR TITLE
Display thread details if thread name is missing

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -15,6 +15,7 @@ export interface Thread {
 	id: number;
 	targetId: string;
 	name?: string;
+	details?: string;
 }
 
 export interface Stack {

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -612,6 +612,11 @@ export class MI2 extends EventEmitter implements IBackend {
 				ret.name = name;
 			}
 
+			const details = MINode.valueOf(element, "details");
+			if (details) {
+				ret.details = details;
+			}
+
 			return ret;
 		});
 	}

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -277,6 +277,9 @@ export class MI2DebugSession extends DebugSession {
 					let threadName = thread.name;
 					// TODO: Thread names are undefined on LLDB
 					if (threadName === undefined) {
+						threadName = thread.details;
+					}
+					if (threadName === undefined) {
 						threadName = thread.targetId;
 					}
 					if (threadName === undefined) {


### PR DESCRIPTION
thread name information is present in thread details column in gdb server.  Use this details information is name is missing. 