### PR TITLE
add support for gdb path substitution

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 							},
 							"pathSubstitutions": {
 								"type": "object",
-								"description": "Help GDB find your source using path substitutions (GDB `substitute-path` variable",
+								"description": "Help GDB find your source using path substitutions (GDB `substitute-path)` variable",
 								"default": {
 									"<fromPath>": "<toPath>"
 								}
@@ -261,7 +261,7 @@
 							},
 							"pathSubstitutions": {
 								"type": "object",
-								"description": "Help GDB find your source using path substitutions (GDB `substitute-path` variable",
+								"description": "Help GDB find your source using path substitutions (GDB `substitute-path)` variable",
 								"default": {
 									"<fromPath>": "<toPath>"
 								}
@@ -531,7 +531,7 @@
 							},
 							"pathSubstitutions": {
 								"type": "object",
-								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map` variable",
+								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map)` variable",
 								"default": {
 									"<fromPath>": "<toPath>"
 								}
@@ -678,7 +678,7 @@
 							},
 							"pathSubstitutions": {
 								"type": "object",
-								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map` variable",
+								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map)` variable",
 								"default": {
 									"<fromPath>": "<toPath>"
 								}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"native",
 		"debug"
 	],
-	"version": "0.24.0",
+	"version": "0.25.0",
 	"publisher": "webfreak",
 	"icon": "images/icon.png",
 	"engines": {
@@ -106,6 +106,13 @@
 								"type": "array",
 								"description": "Additional arguments to pass to GDB",
 								"default": []
+							},
+							"pathSubstitutions": {
+								"type": "object",
+								"description": "Help GDB find your source using path substitutions (GDB `substitute-path` variable",
+								"default": {
+									"<fromPath>": "<toPath>"
+								}
 							},
 							"valuesFormatting": {
 								"type": "string",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"native",
 		"debug"
 	],
-	"version": "0.25.0",
+	"version": "0.24.0",
 	"publisher": "webfreak",
 	"icon": "images/icon.png",
 	"engines": {
@@ -258,6 +258,13 @@
 								"type": "array",
 								"description": "Additional arguments to pass to GDB",
 								"default": []
+							},
+							"pathSubstitutions": {
+								"type": "object",
+								"description": "Help GDB find your source using path substitutions (GDB `substitute-path` variable",
+								"default": {
+									"<fromPath>": "<toPath>"
+								}
 							},
 							"cwd": {
 								"type": "string",
@@ -522,6 +529,13 @@
 								"description": "Additional arguments to pass to LLDB",
 								"default": []
 							},
+							"pathSubstitutions": {
+								"type": "object",
+								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map` variable",
+								"default": {
+									"<fromPath>": "<toPath>"
+								}
+							},
 							"valuesFormatting": {
 								"type": "string",
 								"description": "Set the way of showing variable values. 'disabled' - show value as is, 'parseText' - parse debuggers output text into structure, 'prettyPrinters' - enable debuggers custom pretty-printers if there are any",
@@ -661,6 +675,13 @@
 								"type": "array",
 								"description": "Additional arguments to pass to LLDB",
 								"default": []
+							},
+							"pathSubstitutions": {
+								"type": "object",
+								"description": "Help LLDB find your source using path substitutions (LLDB `target.source-map` variable",
+								"default": {
+									"<fromPath>": "<toPath>"
+								}
 							},
 							"cwd": {
 								"type": "string",

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -27,7 +27,7 @@ function couldBeOutput(line: string) {
 const trace = false;
 
 export class MI2 extends EventEmitter implements IBackend {
-	constructor(public application: string, public preargs: string[], public extraargs: string[], procEnv: any) {
+	constructor(public application: string, public preargs: string[], public extraargs: string[], procEnv: any, public pathSubstitutions: any = {}) {
 		super();
 
 		if (procEnv) {
@@ -197,6 +197,10 @@ export class MI2 extends EventEmitter implements IBackend {
 			cmds.push(this.sendCommand("file-exec-and-symbols \"" + escape(target) + "\""));
 		if (this.prettyPrint)
 			cmds.push(this.sendCommand("enable-pretty-printing"));
+		
+		for (const key in this.pathSubstitutions) {
+			cmds.push(this.sendCommand("gdb-set substitute-path " + key + " " + this.pathSubstitutions[key]));
+		};
 
 		return cmds;
 	}

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -27,7 +27,7 @@ function couldBeOutput(line: string) {
 const trace = false;
 
 export class MI2 extends EventEmitter implements IBackend {
-	constructor(public application: string, public preargs: string[], public extraargs: string[], procEnv: any, public pathSubstitutions: any = {}) {
+	constructor(public application: string, public preargs: string[], public extraargs: string[], procEnv: any, public extraCommands: string[] = []) {
 		super();
 
 		if (procEnv) {
@@ -197,10 +197,9 @@ export class MI2 extends EventEmitter implements IBackend {
 			cmds.push(this.sendCommand("file-exec-and-symbols \"" + escape(target) + "\""));
 		if (this.prettyPrint)
 			cmds.push(this.sendCommand("enable-pretty-printing"));
-		
-		for (const key in this.pathSubstitutions) {
-			cmds.push(this.sendCommand("gdb-set substitute-path " + key + " " + this.pathSubstitutions[key]));
-		};
+		for (let cmd of this.extraCommands) {
+			cmds.push(this.sendCommand(cmd));
+		}
 
 		return cmds;
 	}

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -10,7 +10,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	gdbpath: string;
 	env: any;
 	debugger_args: string[];
-	pathSubstitutions: any; 
+	pathSubstitutions: { [index: string]: string };
 	arguments: string;
 	terminal: string;
 	autorun: string[];
@@ -26,7 +26,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	gdbpath: string;
 	env: any;
 	debugger_args: string[];
-	pathSubstitutions: any;
+	pathSubstitutions: { [index: string]: string };
 	executable: string;
 	remote: boolean;
 	autorun: string[];
@@ -50,7 +50,8 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env, args.pathSubstitutions);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -119,7 +120,8 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env, args.pathSubstitutions);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = !args.remote;
@@ -177,6 +179,15 @@ class GDBDebugSession extends MI2DebugSession {
 					this.sendErrorResponse(response, 101, `Failed to attach: ${err.toString()}`);
 				});
 			}
+		}
+	}
+
+	// Add extra commands for source file path substitution in GDB-specific syntax
+	protected setPathSubstitutions(substitutions: { [index: string]: string }): void {
+		if (substitutions) {
+			Object.keys(substitutions).forEach(source => {
+				this.miDebugger.extraCommands.push("gdb-set substitute-path " + source + " " + substitutions[source]);
+			})
 		}
 	}
 }

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -10,6 +10,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	gdbpath: string;
 	env: any;
 	debugger_args: string[];
+	pathSubstitutions: any; 
 	arguments: string;
 	terminal: string;
 	autorun: string[];
@@ -25,6 +26,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	gdbpath: string;
 	env: any;
 	debugger_args: string[];
+	pathSubstitutions: any;
 	executable: string;
 	remote: boolean;
 	autorun: string[];
@@ -48,7 +50,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env, args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -117,7 +119,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env, args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = !args.remote;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -122,6 +122,15 @@ class LLDBDebugSession extends MI2DebugSession {
 			this.sendResponse(response);
 		});
 	}
+
+	// Add extra commands for source file path substitution in LLDB-specific syntax
+	protected setPathSubstitutions(substitutions: { [index: string]: string }): void {
+		if (substitutions) {
+			Object.keys(substitutions).forEach(source => {
+				this.miDebugger.extraCommands.push("settings set target.source-map " + source + " " + substitutions[source]);
+			})
+		}
+	}
 }
 
 DebugSession.run(LLDBDebugSession);


### PR DESCRIPTION
When debugging a binary, if the build environment is different from the debugging environment (e.g., built in Docker, debugging locally) you might see errors where the debugger isn't able to find the source files that match up with the binary.  This manifests in the extension as error messages in the debug console along the lines of "No source file named ...".

GDB solves this problem with "path substitutions" in a variable.  So if you build a binary in `/root` and want to debug it in `/home/username` you need to issue the command `set substitute-path /root /home/username`. 

This PR adds a configuration option for `launch.json` that lets you set this.