### PR TITLE
mibase: Use 16 bits for thread id instead of 8

### DIFF
--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -288,12 +288,12 @@ export class MI2DebugSession extends DebugSession {
 			});
 	}
 
-	// Supports 256 threads.
+	// Supports 65535 threads.
 	protected threadAndLevelToFrameId(threadId: number, level: number) {
-		return level << 8 | threadId;
+		return level << 16 | threadId;
 	}
 	protected frameIdToThreadAndLevel(frameId: number) {
-		return [frameId & 0xff, frameId >> 8];
+		return [frameId & 0xffff, frameId >> 16];
 	}
 
 	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): void {


### PR DESCRIPTION
Unfortunately the application I'm currently working with spawns and closes large numbers of threads, so while only ~200 or so are running at once, it's not unreasonable for thread ids to get up into the 10,000's. 

This should still support 15 bits of levels before signed-ness becomes an issue, but I can't foresee large frame numbers being as common as large numbers of threads.