### PR TITLE
Clear breakpoints only within the same file.

### DIFF
--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -64,7 +64,7 @@ export interface IBackend {
 	loadBreakPoints(breakpoints: Breakpoint[]): Thenable<[boolean, Breakpoint][]>;
 	addBreakPoint(breakpoint: Breakpoint): Thenable<[boolean, Breakpoint]>;
 	removeBreakPoint(breakpoint: Breakpoint): Thenable<boolean>;
-	clearBreakPoints(): Thenable<any>;
+	clearBreakPoints(source?: string): Thenable<any>;
 	getThreads(): Thenable<Thread[]>;
 	getStack(maxLevels: number, thread: number): Thenable<Stack[]>;
 	getStackVariables(thread: number, frame: number): Thenable<Variable[]>;

--- a/src/backend/mi2/mi2lldb.ts
+++ b/src/backend/mi2/mi2lldb.ts
@@ -40,16 +40,21 @@ export class MI2_LLDB extends MI2 {
 		});
 	}
 
-	clearBreakPoints(): Thenable<any> {
+	clearBreakPoints(source?: string): Thenable<any> {
 		return new Promise((resolve, reject) => {
 			const promises = [];
-			this.breakpoints.forEach((k, index) => {
-				promises.push(this.sendCommand("break-delete " + k).then((result) => {
-					if (result.resultRecords.resultClass == "done") resolve(true);
-					else resolve(false);
-				}));
+			const breakpoints = this.breakpoints;
+			this.breakpoints = new Map();
+			breakpoints.forEach((k, index) => {
+				if (index.file === source) {
+					promises.push(this.sendCommand("break-delete " + k).then((result) => {
+						if (result.resultRecords.resultClass == "done") resolve(true);
+						else resolve(false);
+					}));
+				} else {
+					this.breakpoints.set(index, k);
+				}
 			});
-			this.breakpoints.clear();
 			Promise.all(promises).then(resolve, reject);
 		});
 	}

--- a/src/backend/mi2/mi2lldb.ts
+++ b/src/backend/mi2/mi2lldb.ts
@@ -40,25 +40,6 @@ export class MI2_LLDB extends MI2 {
 		});
 	}
 
-	clearBreakPoints(source?: string): Thenable<any> {
-		return new Promise((resolve, reject) => {
-			const promises = [];
-			const breakpoints = this.breakpoints;
-			this.breakpoints = new Map();
-			breakpoints.forEach((k, index) => {
-				if (index.file === source) {
-					promises.push(this.sendCommand("break-delete " + k).then((result) => {
-						if (result.resultRecords.resultClass == "done") resolve(true);
-						else resolve(false);
-					}));
-				} else {
-					this.breakpoints.set(index, k);
-				}
-			});
-			Promise.all(promises).then(resolve, reject);
-		});
-	}
-
 	setBreakPointCondition(bkptNum, condition): Thenable<any> {
 		return this.sendCommand("break-condition " + bkptNum + " \"" + escape(condition) + "\" 1");
 	}

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -228,7 +228,7 @@ export class MI2DebugSession extends DebugSession {
 	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): void {
 		const cb = (() => {
 			this.debugReady = true;
-			this.miDebugger.clearBreakPoints().then(() => {
+			this.miDebugger.clearBreakPoints(args.source.path).then(() => {
 				let path = args.source.path;
 				if (this.isSSH) {
 					// trimCWD is the local path, switchCWD is the ssh path


### PR DESCRIPTION
Trying to fix #230.

When user set/remove a breakpoint, code-debug will remove all breakpoints and then add back the ones within the same file. That cause the breakpoints in other files lost.
This patch is trying to fix it by removing only the ones within the same file.