### PR TITLE
allow untrusted workspaces to be debugged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 0.25.1
 
-* Remove the need for extra trust for debugging workspaces per guidance "for debug extensions" as noted in the [Workspace Trust Extension Guide](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603)
+* Remove the need for extra trust for debugging workspaces per guidance "for debug extensions" as noted in the [Workspace Trust Extension Guide](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603) (@GitMensch)
+* Fix simple value formatting list parsing with empty string as first argument (@nomtats)
+* don't abort if `set target-async` or `cd` fails in attach (brings in line with existing behavior from launch)
 
 # 0.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.25.1
+
+* Remove the need for extra trust for debugging workspaces per guidance "for debug extensions" as noted in the [Workspace Trust Extension Guide](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603)
+
 # 0.25.0
 
 (Released May 2020)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"debug"
 	],
 	"license": "public domain",
-	"version": "0.25.0",
+	"version": "0.25.1",
 	"publisher": "webfreak",
 	"icon": "images/icon.png",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
 		"type": "git",
 		"url": "https://github.com/WebFreak001/code-debug.git"
 	},
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
 	"contributes": {
 		"commands": [
 			{


### PR DESCRIPTION
Per "guidance for debug extensions" as noted in the [Workspace Trust Extension Guide](https://github.com/microsoft/vscode/issues/120251#issuecomment-825832603).