### PR TITLE
Correct a number of issues related to path substitutions.

### DIFF
--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -1,7 +1,7 @@
 import { MI2DebugSession } from './mibase';
 import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
-import { MI2 } from "./backend/mi2/mi2";
+import { MI2, escape } from "./backend/mi2/mi2";
 import { SSHArguments, ValuesFormattingMode } from './backend/backend';
 
 export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
@@ -186,7 +186,7 @@ class GDBDebugSession extends MI2DebugSession {
 	protected setPathSubstitutions(substitutions: { [index: string]: string }): void {
 		if (substitutions) {
 			Object.keys(substitutions).forEach(source => {
-				this.miDebugger.extraCommands.push("gdb-set substitute-path " + source + " " + substitutions[source]);
+				this.miDebugger.extraCommands.push("gdb-set substitute-path \"" + escape(source) + "\" \"" + escape(substitutions[source]) + "\"");
 			})
 		}
 	}

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -10,6 +10,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	lldbmipath: string;
 	env: any;
 	debugger_args: string[];
+	pathSubstitutions: { [index: string]: string };
 	arguments: string;
 	autorun: string[];
 	ssh: SSHArguments;
@@ -24,6 +25,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	lldbmipath: string;
 	env: any;
 	debugger_args: string[];
+	pathSubstitutions: { [index: string]: string };
 	executable: string;
 	autorun: string[];
 	valuesFormatting: ValuesFormattingMode;
@@ -44,6 +46,7 @@ class LLDBDebugSession extends MI2DebugSession {
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
+		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -105,6 +108,7 @@ class LLDBDebugSession extends MI2DebugSession {
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
 		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
+		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;
@@ -127,7 +131,7 @@ class LLDBDebugSession extends MI2DebugSession {
 	protected setPathSubstitutions(substitutions: { [index: string]: string }): void {
 		if (substitutions) {
 			Object.keys(substitutions).forEach(source => {
-				this.miDebugger.extraCommands.push("settings set target.source-map " + source + " " + substitutions[source]);
+				this.miDebugger.extraCommands.push("settings append target.source-map " + source + " " + substitutions[source]);
 			})
 		}
 	}


### PR DESCRIPTION
Fixes #293 and #294.

LLDB path substitutions were not functional since the path commands
were not being sent to the debugger for any of the configurations.
Additionally, the "settings set target.source-map" command was changed
to "settings append target.source-map" to allow for multiple paths to
be specified.  This command also needed to be sent to the debugger as
a "normal command", as it is not part of the MI.

GDB path substitutions were functional for the launch configuration
and SSH, but were not functional for the attach configuration.
Additionally, the paths were not escaped in the "gdb-set
substitute-path" command, therefore Windows/DOS paths were not
preserved correctly.