### PR TITLE
Add control over continuing on attach.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ port and optionally hostname in `target`.
 This will attach to the running process managed by gdbserver on localhost:2345. You might
 need to hit the start button in the debug bar at the top first to start the program.
 
+Control over whether the debugger should continue executing on connect can be configured
+by setting `stopAtConnect`.  The default value is `false` so that execution will continue
+after connecting.
+
 ### Using ssh for remote debugging
 
 Debugging using ssh automatically converts all paths between client & server and also optionally

--- a/package.json
+++ b/package.json
@@ -867,6 +867,11 @@
 								"type": "array",
 								"description": "mago commands to run when starting to debug",
 								"default": []
+							},
+							"stopAtConnect": {
+								"type": "boolean",
+								"description": "Whether debugger should stop after connecting to target",
+								"default": false
 							}
 						}
 					}

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -30,6 +30,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	executable: string;
 	remote: boolean;
 	autorun: string[];
+	stopAtConnect: boolean;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
@@ -125,7 +126,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.initDebugger();
 		this.quit = false;
 		this.attached = !args.remote;
-		this.needContinue = true;
+		this.needContinue = !args.stopAtConnect;
 		this.isSSH = false;
 		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -28,6 +28,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	pathSubstitutions: { [index: string]: string };
 	executable: string;
 	autorun: string[];
+	stopAtConnect: boolean;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
@@ -112,7 +113,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;
-		this.needContinue = true;
+		this.needContinue = !args.stopAtConnect;
 		this.isSSH = false;
 		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -25,6 +25,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	debugger_args: string[];
 	executable: string;
 	autorun: string[];
+	stopAtConnect: boolean;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
@@ -83,7 +84,7 @@ class MagoDebugSession extends MI2DebugSession {
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;
-		this.needContinue = true;
+		this.needContinue = !args.stopAtConnect;
 		this.isSSH = false;
 		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);


### PR DESCRIPTION
Fixes #244.

This uses `stopAtConnect` instead of #244's suggested `haltOnAttach` terminology in order to be consistent with other debug extensions providing this capability.

Allow configuration control over whether execution should continue
after attaching to target.  This is especially useful for remote
debugging when the remote debugger may already be sitting at the
desired location and continuing would not be the appropriate action.