### PR TITLE
Update launch to wait for configuration completion before running.

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -381,15 +381,13 @@ export class MI2 extends EventEmitter implements IBackend {
 
 	start(): Thenable<boolean> {
 		return new Promise((resolve, reject) => {
-			this.once("ui-break-done", () => {
-				this.log("console", "Running executable");
-				this.sendCommand("exec-run").then((info) => {
-					if (info.resultRecords.resultClass == "running")
-						resolve(undefined);
-					else
-						reject();
-				}, reject);
-			});
+			this.log("console", "Running executable");
+			this.sendCommand("exec-run").then((info) => {
+				if (info.resultRecords.resultClass == "running")
+					resolve(undefined);
+				else
+					reject();
+			}, reject);
 		});
 	}
 

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -1,4 +1,4 @@
-import { MI2DebugSession } from './mibase';
+import { MI2DebugSession, RunCommand } from './mibase';
 import { DebugSession, InitializedEvent, TerminatedEvent, StoppedEvent, OutputEvent, Thread, StackFrame, Scope, Source, Handles } from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol';
 import { MI2_LLDB } from "./backend/mi2/mi2lldb";
@@ -51,7 +51,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
-		this.needContinue = false;
+		this.initialRunCommand = RunCommand.RUN;
 		this.isSSH = false;
 		this.started = false;
 		this.crashed = false;
@@ -78,15 +78,7 @@ class LLDBDebugSession extends MI2DebugSession {
 					args.autorun.forEach(command => {
 						this.miDebugger.sendUserInput(command);
 					});
-				setTimeout(() => {
-					this.miDebugger.emit("ui-break-done");
-				}, 50);
 				this.sendResponse(response);
-				this.miDebugger.start().then(() => {
-					this.started = true;
-					if (this.crashed)
-						this.handlePause(undefined);
-				});
 			});
 		} else {
 			this.miDebugger.load(args.cwd, args.target, args.arguments, undefined).then(() => {
@@ -94,15 +86,7 @@ class LLDBDebugSession extends MI2DebugSession {
 					args.autorun.forEach(command => {
 						this.miDebugger.sendUserInput(command);
 					});
-				setTimeout(() => {
-					this.miDebugger.emit("ui-break-done");
-				}, 50);
 				this.sendResponse(response);
-				this.miDebugger.start().then(() => {
-					this.started = true;
-					if (this.crashed)
-						this.handlePause(undefined);
-				});
 			});
 		}
 	}
@@ -113,7 +97,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;
-		this.needContinue = !args.stopAtConnect;
+		this.initialRunCommand = !!args.stopAtConnect ? RunCommand.NONE : RunCommand.CONTINUE;
 		this.isSSH = false;
 		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);


### PR DESCRIPTION
This removes the run timer as discussed in #303.

Removed the timer which was previously used to trigger execution of
the run command in the launch configurations and instead updated the
launch configuration to behave like the attach configuration.  This
now waits until the configurationDoneRequest is received before
sending the run command to the debugger.  This is expected to address
race conditions where breakpoints were not being hit due to the
application running prior to the breakpoints having been configured in
the debugger.