### PR TITLE
Add configuration to run debugger to application's entry point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ in `stdout` for the application, `stderr` for errors and `log` for log messages.
 Some exceptions/signals like segmentation faults will be catched and displayed but
 it does not support for example most D exceptions.
 
+Support exists for stopping at the entry point of the application.  This is controlled
+through the `stopAtEntry` setting.  This value may be either a boolean or a string.  In
+the case of a boolean value of `false` (the default), this setting is disabled.  In the
+case of a boolean value of `true`, if this is a launch configuration and the debugger
+supports the `start` (or `exec-run --start` MI feature, more specifically), than this
+will be used to run to the entry point of the application.  Note that this appears to
+work fine for GDB, but LLDB doesn't necessarily seem to adhere to this, even though it may
+indicate that it supports this feature.  The alternative configuration option for the
+`stopAtEntry` setting is to specify a string where the string represents the entry point
+itself.  In this situation a temporary breakpoint will be set at the specified entry point
+and a normal run will occur for a launch configuration.  This (setting a temporary
+breakpoint) is also the behavior that occurs when the debugger does not support the
+`start` feature and the `stopAtEntry` was set to `true`.  In that case the entry point will
+default to "main".  Thus, the most portable way to use this configuration is to explicitly
+specify the entry point of the application.  In the case of an attach configuration, similar
+behavior will occur, however since there is no equivalent of the `start` command for
+attaching, a boolean value of `true` for the `stopAtEntry` setting in a launch configuration
+will automatically default to an entry point of "main", while a string value for this
+setting will be interpreted as the entry point, causing a temporary breakpoint to be set at
+that location prior to continuing execution.  Note that stopping at the entry point for the
+attach configuration assumes that the entry point has not yet been entered at the time of
+attach, otherwise this will have no affect.
+
 ### Attaching to existing processes
 
 Attaching to existing processes currently only works by specifying the PID in the

--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
 								"description": "GDB commands to run when starting to debug",
 								"default": []
 							},
+							"stopAtEntry": {
+								"type": ["boolean", "string"],
+								"description": "Whether debugger should stop at application entry point",
+								"default": false
+							},
 							"ssh": {
 								"required": [
 									"host",
@@ -304,6 +309,11 @@
 							"stopAtConnect": {
 								"type": "boolean",
 								"description": "Whether debugger should stop after connecting to target",
+								"default": false
+							},
+							"stopAtEntry": {
+								"type": ["boolean", "string"],
+								"description": "Whether debugger should stop at application entry point",
 								"default": false
 							},
 							"ssh": {
@@ -579,6 +589,11 @@
 								"description": "lldb commands to run when starting to debug",
 								"default": []
 							},
+							"stopAtEntry": {
+								"type": ["boolean", "string"],
+								"description": "Whether debugger should stop at application entry point",
+								"default": false
+							},
 							"ssh": {
 								"required": [
 									"host",
@@ -714,6 +729,11 @@
 							"stopAtConnect": {
 								"type": "boolean",
 								"description": "Whether debugger should stop after connecting to target",
+								"default": false
+							},
+							"stopAtEntry": {
+								"type": ["boolean", "string"],
+								"description": "Whether debugger should stop at application entry point",
 								"default": false
 							}
 						}

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -53,7 +53,7 @@ export interface IBackend {
 	ssh(args: SSHArguments, cwd: string, target: string, procArgs: string, separateConsole: string, attach: boolean): Thenable<any>;
 	attach(cwd: string, executable: string, target: string): Thenable<any>;
 	connect(cwd: string, executable: string, target: string): Thenable<any>;
-	start(): Thenable<boolean>;
+	start(runToStart: boolean): Thenable<boolean>;
 	stop();
 	detach();
 	interrupt(): Thenable<boolean>;

--- a/src/backend/mi2/mi2lldb.ts
+++ b/src/backend/mi2/mi2lldb.ts
@@ -15,7 +15,16 @@ export class MI2_LLDB extends MI2 {
 				target = nativePath.join(cwd, target);
 		}
 		const cmds = [
-			this.sendCommand("gdb-set target-async on")
+			this.sendCommand("gdb-set target-async on"),
+			new Promise(resolve => {
+				this.sendCommand("list-features").then(done => {
+					this.features = done.result("features");
+					resolve(undefined);
+				}, err => {
+					this.features = [];
+					resolve(undefined);
+				});
+			})
 		];
 		if (!attach)
 			cmds.push(this.sendCommand("file-exec-and-symbols \"" + escape(target) + "\""));

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -14,6 +14,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	arguments: string;
 	terminal: string;
 	autorun: string[];
+	stopAtEntry: boolean | string;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
@@ -31,6 +32,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	remote: boolean;
 	autorun: string[];
 	stopAtConnect: boolean;
+	stopAtEntry: boolean | string;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
@@ -64,6 +66,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.stopAtEntry = args.stopAtEntry;
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;
@@ -112,6 +115,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.stopAtEntry = args.stopAtEntry;
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -13,6 +13,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	pathSubstitutions: { [index: string]: string };
 	arguments: string;
 	autorun: string[];
+	stopAtEntry: boolean | string;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
@@ -29,6 +30,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	executable: string;
 	autorun: string[];
 	stopAtConnect: boolean;
+	stopAtEntry: boolean | string;
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
@@ -59,6 +61,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.stopAtEntry = args.stopAtEntry;
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;
@@ -103,6 +106,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.stopAtEntry = args.stopAtEntry;
 		this.miDebugger.attach(args.cwd, args.executable, args.target).then(() => {
 			if (args.autorun)
 				args.autorun.forEach(command => {

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -330,7 +330,7 @@ export class MI2DebugSession extends DebugSession {
 
 	protected configurationDoneRequest(response: DebugProtocol.ConfigurationDoneResponse, args: DebugProtocol.ConfigurationDoneArguments): void {
 		const promises: Thenable<any>[] = [];
-		let entryPoint: string = undefined;
+		let entryPoint: string | undefined = undefined;
 		let runToStart: boolean = false;
 		// Setup temporary breakpoint for the entry point if needed.
 		switch (this.initialRunCommand) {


### PR DESCRIPTION
This adds a new stopAtEntry configuration option which can be used to
command the extension to run the application up to its entry point.
This can be used for both launch and attach configurations.  For
launch configurations, the debugger's "start" command will be used if
available, otherwise a temporary breakpoint will be set at the entry
point and execution will be commanded (to allow running to the
breakpoint).  When no entry point is provided for an attach
configuration the extension will default the entry point to "main" as
a reasonable default.  When no entry point is provided for a launch
configuration and the debugger does not support the "start" command,
the extension will also default the entry point to "main" as well.
The user can explicitly specify the entry point, in which case that
will be used to set a temporary breakpoint.