### PR TITLE
Add support for 'startFrame' parameter in stack trace.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,15 @@
 * SSH2 module updated from deprecated 0.8.9 to current 1.6.0 (@GitMensch),
   allowing connections with more modern key algorithms, improved error handling (including user messages passed on) and other improvements.  
   See [SSH2 Update Notices](https://github.com/mscdex/ssh2/issues/935) for more details.
-* Path Substitions working with attach+ssh configuration #293 (@brownts)
-* Path Substitions working with LLDB #295 (@brownts)
-* Path Substitions working with Windows-Style paths #294 (@brownts)
+* Path Substitutions working with attach+ssh configuration #293 (@brownts)
+* Path Substitutions working with LLDB #295 (@brownts)
+* Path Substitutions working with Windows-Style paths #294 (@brownts)
 * Breakpoints may be deleted when not recognized correctly #259 fixing #230 (@kvinwang)
 * New `stopAtConnect` configuration #299, #302 (@brownts)
 * New `stopAtEntry` configuration to run debugger to application's entry point #306 (@brownts)
 * fix for race conditions on startup where breakpoints were not hit #304 (@brownts)
 * fix additional race conditions with setting breakpoints #313 (@brownts)
+* fix stack frame expansion in editor via use of the `startFrame` parameter #312 (@brownts)
 
 # 0.25.1
 

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -66,7 +66,7 @@ export interface IBackend {
 	removeBreakPoint(breakpoint: Breakpoint): Thenable<boolean>;
 	clearBreakPoints(source?: string): Thenable<any>;
 	getThreads(): Thenable<Thread[]>;
-	getStack(maxLevels: number, thread: number): Thenable<Stack[]>;
+	getStack(startFrame: number, maxLevels: number, thread: number): Thenable<Stack[]>;
 	getStackVariables(thread: number, frame: number): Thenable<Variable[]>;
 	evalExpression(name: string, thread: number, frame: number): Thenable<any>;
 	isReady(): boolean;

--- a/src/backend/mi2/mi2mago.ts
+++ b/src/backend/mi2/mi2mago.ts
@@ -3,7 +3,7 @@ import { Stack } from "../backend";
 import { MINode } from "../mi_parse";
 
 export class MI2_Mago extends MI2_LLDB {
-	getStack(maxLevels: number, thread: number): Promise<Stack[]> {
+	getStack(startFrame: number, maxLevels: number, thread: number): Promise<Stack[]> {
 		return new Promise((resolve, reject) => {
 			const command = "stack-list-frames";
 			this.sendCommand(command).then((result) => {

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -279,7 +279,7 @@ export class MI2DebugSession extends DebugSession {
 	}
 
 	protected stackTraceRequest(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): void {
-		this.miDebugger.getStack(args.levels, args.threadId).then(stack => {
+		this.miDebugger.getStack(args.startFrame, args.levels, args.threadId).then(stack => {
 			const ret: StackFrame[] = [];
 			stack.forEach(element => {
 				let source = undefined;


### PR DESCRIPTION
Fixes #308.

When a stack trace contains many functions calls, the 'startFrame' can
be used in subsequent calls to expand a subset of the complete stack
trace.  Although this parameter is optional, if not utilized, it can
prohibit the interrogation of a long list of stack frames when
combined with the 'levels' parameter.