### PR TITLE
Implement well defined window for breakpoint configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * New `stopAtConnect` configuration #299, #302 (@brownts)
 * New `stopAtEntry` configuration to run debugger to application's entry point #306 (@brownts)
 * fix for race conditions on startup where breakpoints were not hit #304 (@brownts)
+* fix additional race conditions with setting breakpoints #313 (@brownts)
 
 # 0.25.1
 

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -62,7 +62,6 @@ class GDBDebugSession extends MI2DebugSession {
 		this.isSSH = false;
 		this.started = false;
 		this.crashed = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
@@ -111,7 +110,6 @@ class GDBDebugSession extends MI2DebugSession {
 		this.attached = !args.remote;
 		this.initialRunCommand = !!args.stopAtConnect ? RunCommand.NONE : RunCommand.CONTINUE;
 		this.isSSH = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -57,7 +57,6 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.isSSH = false;
 		this.started = false;
 		this.crashed = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
@@ -102,7 +101,6 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.attached = true;
 		this.initialRunCommand = !!args.stopAtConnect ? RunCommand.NONE : RunCommand.CONTINUE;
 		this.isSSH = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -58,7 +58,6 @@ class MagoDebugSession extends MI2DebugSession {
 		this.isSSH = false;
 		this.started = false;
 		this.crashed = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
@@ -78,7 +77,6 @@ class MagoDebugSession extends MI2DebugSession {
 		this.attached = true;
 		this.initialRunCommand = !!args.stopAtConnect ? RunCommand.NONE : RunCommand.CONTINUE;
 		this.isSSH = false;
-		this.debugReady = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;


### PR DESCRIPTION
Fixes #307.

The previous implementation worked under the assumption that
breakpoint requests would be received from the client prior to the
debugger having completed it's initialization.  However, if the
debugger completed initialization prior to having received breakpoint
requests from the client, those breakpoints requests would be
ignored (i.e., there was a race condition).  Additionally, the
previous implementation "buffered" the receipt of the breakpoint
requests and would only process them after the debugger initialization
had completed (i.e., "debug-ready").

This change delays the sending of the "initialized" event back to the
client (until the debugger truly has completed its initialization).
As a result, there is no longer a need to buffer the breakpoint
requests.  Breakpoints requests are now forced to be received after
the debugger has been initialized.  Furthermore, a previous change
prevented running the application until after the "configurationDone"
request is received.  Therefore, with this change, there is now a well
defined window (between sending the "initialized" event and receiving
the "configurationDone" request), for breakpoint configuration to
occur.