### PR TITLE
Update dependencies to one-year old vscode + dap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased 0.26.0
 
+* vscode dependency was increased from 1.28 to 1.55 along with the debug-adapter protocol to get rid of some outdated dependencies (@GitMensch)
 * SSH2 module updated from deprecated 0.8.9 to current 1.6.0 (@GitMensch),
   allowing connections with more modern key algorithms, improved error handling (including user messages passed on) and other improvements.  
   See [SSH2 Update Notices](https://github.com/mscdex/ssh2/issues/935) for more details.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"publisher": "webfreak",
 	"icon": "images/icon.png",
 	"engines": {
-		"vscode": "^1.28.0"
+		"vscode": "^1.55.0"
 	},
 	"main": "./out/src/frontend/extension",
 	"activationEvents": [
@@ -997,13 +997,13 @@
 	},
 	"dependencies": {
 		"ssh2": "^1.6.0",
-		"vscode-debugadapter": "^1.40.0",
-		"vscode-debugprotocol": "^1.40.0"
+		"vscode-debugadapter": "^1.45.0",
+		"vscode-debugprotocol": "^1.45.0"
 	},
 	"devDependencies": {
 		"@types/mocha": "^5.2.6",
 		"@types/node": "^11.11.3",
-		"@types/vscode": "^1.28.0",
+		"@types/vscode": "^1.55.0",
 		"mocha": "^9.1.3",
 		"tslint": "^5.20.1",
 		"typescript": "^3.9.3",


### PR DESCRIPTION
tested as following: build with newest environment, run on VSCodium 1.55 (couldn't test a different version).