### PR TITLE
new `ssh.sourceFileMap` configuration for multiple substitutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 * Breakpoints may be deleted when not recognized correctly #259 fixing #230 (@kvinwang)
 * New `stopAtConnect` configuration #299, #302 (@brownts)
 * New `stopAtEntry` configuration to run debugger to application's entry point #306 (@brownts)
+* New `ssh.sourceFileMap` configuration to allow multiple substitutions between local and ssh-remote and separate ssh working directory #298 (@GitMensch)
+* fix path translation for SSH to Win32 and for extended-remote without executable (attach to process) #323 (@GitMensch)
 * fix for race conditions on startup where breakpoints were not hit #304 (@brownts)
 * prevent "Not implemented stop reason (assuming exception)" in many cases #316 (@GitMensch),
   initial recognition of watchpoints

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ after connecting.
 ### Using ssh for debugging on remote
 
 Debugging using ssh automatically converts all paths between client & server and also optionally
-redirects X11 output from the server to the client. Simply add a `ssh` object in your `launch`
-request.
+redirects X11 output from the server to the client.  
+Simply add a `ssh` object in your `launch` request.
 
 ```
 "request": "launch",
@@ -137,8 +137,11 @@ request.
 }
 ```
 
-`cwd` will be used to trim off local paths and `ssh.cwd` will map them to the server. This is
+`ssh.sourceFileMap` will be used to trim off local paths and map them to the server. This is
 required for basically everything except watched variables or user commands to work.
+
+For backward compatibility you can also use `cwd` and `ssh.cwd` for the mapping, this is only used
+if the newer `ssh.sourceFileMap` is not configured.
 
 For X11 forwarding to work you first need to enable it in your Display Manager and allow the
 connections. To allow connections you can either add an entry for applications or run `xhost +`

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project"
+								"description": "project path"
 							},
 							"gdbpath": {
 								"type": "string",
@@ -173,8 +173,8 @@
 							"ssh": {
 								"required": [
 									"host",
-									"cwd",
-									"user"
+									"user",
+									"cwd"
 								],
 								"type": "object",
 								"description": "If this is set then the extension will connect to an ssh host and run GDB there",
@@ -182,10 +182,6 @@
 									"host": {
 										"type": "string",
 										"description": "Remote host name/ip to connect to"
-									},
-									"cwd": {
-										"type": "string",
-										"description": "Path of project on the remote"
 									},
 									"port": {
 										"type": ["number", "string"],
@@ -208,6 +204,17 @@
 										"type": "boolean",
 										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
 										"default": false
+									},
+									"sourceFileMap": {
+										"type": "object",
+										"description": "Mapping of source paths (from GDB on ssh remote) to local (IDE) paths.",
+										"default": {
+											"<sourcePath>": "<localPath>"
+										}
+									},
+									"cwd": {
+										"type": "string",
+										"description": "Working directory for the debugger.\nIf `ssh.sourceFileMap` is not set, then this is also the project path on the remote for mapping with `cwd`."
 									},
 									"forwardX11": {
 										"type": "boolean",
@@ -300,7 +307,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project",
+								"description": "project path",
 								"default": "${workspaceRoot}"
 							},
 							"autorun": {
@@ -331,10 +338,6 @@
 										"type": "string",
 										"description": "Remote host name/ip to connect to"
 									},
-									"cwd": {
-										"type": "string",
-										"description": "Path of project on the remote"
-									},
 									"port": {
 										"type": ["number", "string"],
 										"description": "Remote port number",
@@ -356,6 +359,17 @@
 										"type": "boolean",
 										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
 										"default": false
+									},
+									"sourceFileMap": {
+										"type": "object",
+										"description": "Mapping of source paths (from GDB on ssh remote) to local (IDE) paths.",
+										"default": {
+											"<sourcePath>": "<localPath>"
+										}
+									},
+									"cwd": {
+										"type": "string",
+										"description": "Working directory for the debugger.\nIf `ssh.sourceFileMap` is not set, then this is also the project path on the remote for mapping with `cwd`."
 									},
 									"forwardX11": {
 										"type": "boolean",
@@ -446,9 +460,12 @@
 							"cwd": "^\"\\${workspaceRoot}\"",
 							"ssh": {
 								"host": "${2:127.0.0.1}",
-								"cwd": "${3:/home/remote_user/project/}",
+								"cwd": "${3:/tmp/working}",
 								"keyfile": "${4:/home/my_user/.ssh/id_rsa}",
-								"user": "${5:remote_user}"
+								"user": "${5:remote_user}",
+								"sourceFileMap": {
+									"${6:/home/remote_user/project/}": "^\"\\${workspaceRoot}\""
+								}
 							},
 							"valuesFormatting": "parseText"
 						}
@@ -542,7 +559,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project"
+								"description": "project path"
 							},
 							"lldbmipath": {
 								"type": "string",
@@ -609,10 +626,6 @@
 										"type": "string",
 										"description": "Remote host name/ip to connect to"
 									},
-									"cwd": {
-										"type": "string",
-										"description": "Path of project on the remote"
-									},
 									"port": {
 										"type": ["number", "string"],
 										"description": "Remote port number",
@@ -635,20 +648,31 @@
 										"description": "Auto-detect the running SSH agent (via SSH_AUTH_SOCK environment variable) and use it to perform authentication",
 										"default": false
 									},
+									"sourceFileMap": {
+										"type": "object",
+										"description": "Mapping of source paths (from GDB on ssh remote) to local (IDE) paths.",
+										"default": {
+											"<sourcePath>": "<localPath>"
+										}
+									},
+									"cwd": {
+										"type": "string",
+										"description": "Working directory for the debugger.\nIf `ssh.sourceFileMap` is not set, then this is also the project path on the remote for mapping with `cwd`."
+									},
 									"forwardX11": {
 										"type": "boolean",
 										"description": "If true, the server will redirect x11 to the local host",
 										"default": true
 									},
-									"x11port": {
-										"type": ["number", "string"],
-										"description": "Port to redirect X11 data to (by default port = display + 6000)",
-										"default": 6000
-									},
 									"x11host": {
 										"type": "string",
 										"description": "Hostname/ip to redirect X11 data to",
 										"default": "localhost"
+									},
+									"x11port": {
+										"type": ["number", "string"],
+										"description": "Port to redirect X11 data to (by default port = display + 6000)",
+										"default": 6000
 									},
 									"remotex11screen": {
 										"type": "number",
@@ -720,7 +744,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project",
+								"description": "project path",
 								"default": "${workspaceRoot}"
 							},
 							"autorun": {
@@ -842,7 +866,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project"
+								"description": "project path"
 							},
 							"magomipath": {
 								"type": "string",
@@ -936,7 +960,7 @@
 							},
 							"cwd": {
 								"type": "string",
-								"description": "Path of project",
+								"description": "project path",
 								"default": "${workspaceRoot}"
 							},
 							"autorun": {

--- a/src/backend/backend.ts
+++ b/src/backend/backend.ts
@@ -46,6 +46,7 @@ export interface SSHArguments {
 	x11port: number;
 	x11host: string;
 	bootstrap: string;
+	sourceFileMap: { [index: string]: string };
 }
 
 export interface IBackend {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -78,8 +78,7 @@ class GDBDebugSession extends MI2DebugSession {
 			if (args.ssh.remotex11screen === undefined)
 				args.ssh.remotex11screen = 0;
 			this.isSSH = true;
-			this.trimCWD = args.cwd.replace(/\\/g, "/");
-			this.switchCWD = args.ssh.cwd;
+			this.setSourceFileMap(args.ssh.sourceFileMap, args.ssh.cwd, args.cwd);
 			this.miDebugger.ssh(args.ssh, args.ssh.cwd, args.target, args.arguments, args.terminal, false).then(() => {
 				if (args.autorun)
 					args.autorun.forEach(command => {
@@ -126,8 +125,7 @@ class GDBDebugSession extends MI2DebugSession {
 			if (args.ssh.remotex11screen === undefined)
 				args.ssh.remotex11screen = 0;
 			this.isSSH = true;
-			this.trimCWD = args.cwd.replace(/\\/g, "/");
-			this.switchCWD = args.ssh.cwd;
+			this.setSourceFileMap(args.ssh.sourceFileMap, args.ssh.cwd, args.cwd);
 			this.miDebugger.ssh(args.ssh, args.ssh.cwd, args.target, "", undefined, true).then(() => {
 				if (args.autorun)
 					args.autorun.forEach(command => {

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -73,8 +73,7 @@ class LLDBDebugSession extends MI2DebugSession {
 			if (args.ssh.remotex11screen === undefined)
 				args.ssh.remotex11screen = 0;
 			this.isSSH = true;
-			this.trimCWD = args.cwd.replace(/\\/g, "/");
-			this.switchCWD = args.ssh.cwd;
+			this.setSourceFileMap(args.ssh.sourceFileMap, args.ssh.cwd, args.cwd);
 			this.miDebugger.ssh(args.ssh, args.ssh.cwd, args.target, args.arguments, undefined, false).then(() => {
 				if (args.autorun)
 					args.autorun.forEach(command => {


### PR DESCRIPTION
fixes #298

also allows to have an actual separate ssh working directory


This is tested and works like a charm (yay, finally I can actually set the working directory - because that's not where the sources are), the only reason for requesting a review (feel free to click on "merge pull request") is that @WebFreak001 previously questioned that setting.