### PR TITLE
Run npm compilation command in a shell rather than as a process.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,9 @@
 {
 	"version": "2.0.0",
 
+	// Run in a shell so "npm" command is properly resolved to "npm.cmd" on Windows systems.
+	"type": "shell",
+
 	// we want to run npm
 	"command": "npm",
 


### PR DESCRIPTION
This addresses the issue discussed in https://github.com/WebFreak001/code-debug/issues/305#issuecomment-1086699962

The Windows npm command is actually npm.cmd, but this doesn't work
correctly if the command is run as a process from tasks.json, since it
won't properly resolve the npm command to npm.cmd.  This changes the
task to run the command via a shell so that the necessary translation
is made.  This change will work on both Windows and POSIX systems.