### PR TITLE
Fix MI parser to allow async-record w/o a result.

### DIFF
--- a/src/backend/mi_parse.ts
+++ b/src/backend/mi_parse.ts
@@ -129,7 +129,7 @@ const resultRecordRegex = /^(\d*)\^(done|running|connected|error|exit)/;
 const newlineRegex = /^\r\n?/;
 const endRegex = /^\(gdb\)\r\n?/;
 const variableRegex = /^([a-zA-Z_\-][a-zA-Z0-9_\-]*)/;
-const asyncClassRegex = /^(.*?),/;
+const asyncClassRegex = /^[^,\r\n]+/;
 
 export function parseMI(output: string): MINode {
 	/*
@@ -270,11 +270,11 @@ export function parseMI(output: string): MINode {
 
 		if (match[2]) {
 			const classMatch = asyncClassRegex.exec(output);
-			output = output.substr(classMatch[1].length);
+			output = output.substring(classMatch[0].length);
 			const asyncRecord = {
 				isStream: false,
 				type: asyncRecordType[match[2]],
-				asyncClass: classMatch[1],
+				asyncClass: classMatch[0],
 				output: []
 			};
 			let result;

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -5,9 +5,9 @@ import * as glob from 'glob';
 export function run(): Promise<void> {
   // Create the mocha test
   const mocha = new Mocha({
-    ui: 'tdd'
+    ui: 'tdd',
+    useColors: true
   });
-  mocha.useColors(true);
 
   const testsRoot = path.resolve(__dirname, '..');
 

--- a/src/test/suite/mi_parse.test.ts
+++ b/src/test/suite/mi_parse.test.ts
@@ -2,6 +2,16 @@ import * as assert from 'assert';
 import { parseMI, MINode } from '../../backend/mi_parse';
 
 suite("MI Parse", () => {
+	test("Very simple out of band record", () => {
+		const parsed = parseMI(`*stopped`);
+		assert.ok(parsed);
+		assert.strictEqual(parsed.token, undefined);
+		assert.strictEqual(parsed.outOfBandRecord.length, 1);
+		assert.strictEqual(parsed.outOfBandRecord[0].isStream, false);
+		assert.strictEqual(parsed.outOfBandRecord[0].asyncClass, "stopped");
+		assert.strictEqual(parsed.outOfBandRecord[0].output.length, 0);
+		assert.strictEqual(parsed.resultRecords, undefined);
+	});
 	test("Simple out of band record", () => {
 		const parsed = parseMI(`4=thread-exited,id="3",group-id="i1"`);
 		assert.ok(parsed);


### PR DESCRIPTION
Fixes #339.

This updates the async class regex to not require a trailing comma after
the class name.  Since results are optional, scenarios can exist where
there are no results and the regex no longer matches.

A new test case has also been added to test the parser for this
scenario.