### PR TITLE
Process initial commands before attaching to PID.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * fix stack frame expansion in editor via use of the `startFrame` parameter #312 (@brownts)
 * allow specification of port/x11port via variable (as numeric string) #265 (@GitMensch)
 * Extra debugger arguments now work in all configurations #316, #338 fixing #206 (@GitMensch, @brownts)
+* Attaching to local PID now performs initialization prior to attaching #341 fixing #329 (@brownts)
 
 # 0.25.1
 


### PR DESCRIPTION
Fixes #329.

Instead of specifying the process to attach on the command line, this
update will use the `target-attach` command instead. In this way, the
ordering of the attach with respect to the execution of initial commands
can be controlled.