### PR TITLE
Update Source Path Mapping for case sensitivity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [Unreleased]
 ## Fixed
+* Fixes #346 - Case-sensitivity not respected in SSH path mapping - PR #352 (@brownts)
 * Fixes #342 - Local variables not displayed more than 2 stack frames deep - PR #345 (@brownts)
 
 [Unreleased]: https://github.com/WebFreak001/code-debug/compare/v0.26.0...HEAD

--- a/src/path_kind.ts
+++ b/src/path_kind.ts
@@ -1,0 +1,55 @@
+import * as Path from "path";
+
+export abstract class PathKind {
+	protected abstract readonly path: typeof Path.posix | typeof Path.win32;
+	public abstract readonly caseSensitive: boolean;
+
+	// The path.posix.normalize routine will not convert Win32 path separators
+	// to POSIX separators, so we explictily convert any Win32 path separators
+	// to POSIX style separators.  The path.win32.normalize routine will accept
+	// either Win32 or POSIX style separators and will normalize them to the
+	// Win32 style.  Thus, if we convert all path separators to POSIX style and
+	// then normalize, this will work for both systems.
+	public normalize(p: string): string {
+		return this.path.normalize(p.replace(/\\/g, "/"));
+	}
+
+	public normalizeDir(p: string): string {
+		p = this.normalize(p);
+		if (! p.endsWith(this.path.sep))
+			p = this.path.join(p, this.path.sep);
+		return p;
+	}
+
+	public join(...paths: string[]): string {
+		return this.normalize(this.path.join(...paths));
+	}
+
+	public isAbsolute(p: string): boolean {
+		return this.path.isAbsolute(this.normalize(p));
+	}
+}
+
+export class PathWin32 extends PathKind {
+	protected readonly path: typeof Path.posix | typeof Path.win32 = Path.win32;
+	public readonly caseSensitive: boolean = false;
+	private static instance: PathWin32;
+	private constructor() { super(); }
+	public static getInstance(): PathWin32 {
+		if (! this.instance)
+			this.instance = new PathWin32();
+		return this.instance;
+	}
+}
+
+export class PathPosix extends PathKind {
+	protected readonly path: typeof Path.posix | typeof Path.win32 = Path.posix;
+	public readonly caseSensitive: boolean = true;
+	private static instance: PathPosix;
+	private constructor() { super(); }
+	public static getInstance(): PathPosix {
+		if (! this.instance)
+			this.instance = new PathPosix();
+		return this.instance;
+	}
+}

--- a/src/source_file_map.ts
+++ b/src/source_file_map.ts
@@ -1,0 +1,98 @@
+import { PathKind, PathWin32, PathPosix } from "./path_kind";
+
+interface Mapping {
+	"remote": string;
+	"local": string;
+}
+
+export class SourceFileMap {
+	private sortedMappings: { [key in keyof Mapping]: Mapping[] } = {remote: [], local: []};
+	private nativePath: PathKind;
+
+	constructor (map: { [index: string]: string }) {
+		const mappings: Mapping[] = [];
+		this.nativePath = this.getNativePath();
+		for (let [remotePrefix, localPrefix] of Object.entries(map)) {
+			// Normalize local path, adding trailing separator if missing.
+			localPrefix = this.nativePath.normalizeDir(localPrefix);
+
+			// Try to detect remote path.
+			const debuggerPath: PathKind = SourceFileMap.toPathKind(remotePrefix);
+			// Normalize remote path, adding trailing separator if missing.
+			remotePrefix = debuggerPath.normalizeDir(remotePrefix);
+
+			mappings.push({remote: remotePrefix, local: localPrefix});
+		}
+
+		// Sort with longest paths first in case some paths are subsets, so that
+		// we match the most appropriate (e.g., with path prefixes of '/home'
+		// and '/home/foo', and a complete path of '/home/foo/bar.c', we should
+		// match the '/home/foo' path prefix instead of '/home'.
+		this.sortedMappings.local  = [...mappings].sort((a: Mapping, b: Mapping) => b.local.length - a.local.length);
+		this.sortedMappings.remote = [...mappings].sort((a: Mapping, b: Mapping) => b.remote.length - a.remote.length);
+	}
+
+	// The native path selection is isolated here to allow for easy unit testing
+	// allowing non-native path types to be tested by overriding this method in
+	// a subclass in the test harness.
+	protected getNativePath(): PathKind {
+		if (process.platform == "win32")
+			return PathWin32.getInstance();
+		else
+			return PathPosix.getInstance();
+	}
+
+	private static toPathKind(unknownPath: string): PathKind {
+		const pathPosix: PathKind = PathPosix.getInstance();
+		const pathWin32: PathKind = PathWin32.getInstance();
+		return pathPosix.isAbsolute(unknownPath) ? pathPosix : pathWin32;
+	}
+
+	private pathMatch(key: keyof Mapping, caseSensitive: boolean, path: string): Mapping | undefined {
+		for (const mapping of this.sortedMappings[key]) {
+			let matched: boolean;
+
+			if (caseSensitive)
+				matched = path.startsWith(mapping[key]);
+			else
+				matched = path.toLowerCase().startsWith(mapping[key].toLowerCase());
+
+			if (matched)
+				return mapping;
+		}
+
+		return undefined;
+	}
+
+	public toLocalPath(remotePath: string): string {
+		// Try to detect remote path.
+		const debuggerPath: PathKind = SourceFileMap.toPathKind(remotePath);
+		const normalizedRemotePath: string = debuggerPath.normalize(remotePath);
+		const mapping: Mapping | undefined =
+			this.pathMatch("remote", debuggerPath.caseSensitive, normalizedRemotePath);
+
+		if (mapping) {
+			const pathSuffix = normalizedRemotePath.substring(mapping.remote.length);
+			return this.nativePath.join(mapping.local, pathSuffix);
+		}
+
+		// No mapping found, so return unmapped path.
+		return remotePath;
+	}
+
+	public toRemotePath (localPath: string): string {
+		const normalizedLocalPath = this.nativePath.normalize(localPath);
+		const mapping: Mapping | undefined =
+			this.pathMatch("local", this.nativePath.caseSensitive, normalizedLocalPath);
+
+		if (mapping) {
+			const pathSuffix = normalizedLocalPath.substring(mapping.local.length);
+			// Try to detect remote path.
+			const debuggerPath = SourceFileMap.toPathKind(mapping.remote);
+			return debuggerPath.join(mapping.remote, pathSuffix);
+		}
+
+		// No mapping found, so return unmapped path.
+		return localPath;
+	}
+}

--- a/src/test/suite/path_kind.test.ts
+++ b/src/test/suite/path_kind.test.ts
@@ -1,0 +1,79 @@
+import * as assert from 'assert';
+import { PathKind, PathWin32, PathPosix } from "../../path_kind";
+
+suite("Path Kind", () => {
+	const pathWin32: PathKind = PathWin32.getInstance();
+	const pathPosix: PathKind = PathPosix.getInstance();
+	test("Normalize", () => {
+		assert.strictEqual(pathWin32.normalize("C:/foo/bar"), "C:\\foo\\bar");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\bar"), "C:\\foo\\bar");
+		assert.strictEqual(pathWin32.normalize("C:/foo/bar/"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\bar\\"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\bar\\.."), "C:\\foo");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\bar\\..\\"), "C:\\foo\\");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\..\\bar"), "C:\\bar");
+		assert.strictEqual(pathWin32.normalize("C:\\foo\\..\\bar\\"), "C:\\bar\\");
+
+		assert.strictEqual(pathPosix.normalize("\\home\\foo\\bar"), "/home/foo/bar");
+		assert.strictEqual(pathPosix.normalize("/home/foo/bar"), "/home/foo/bar");
+		assert.strictEqual(pathPosix.normalize("\\home\\foo\\bar\\"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalize("/home/foo/bar/"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalize("/home/foo/bar/.."), "/home/foo");
+		assert.strictEqual(pathPosix.normalize("/home/foo/bar/../"), "/home/foo/");
+		assert.strictEqual(pathPosix.normalize("/home/foo/../bar"), "/home/bar");
+		assert.strictEqual(pathPosix.normalize("/home/foo/../bar/"), "/home/bar/");
+	});
+	test("Normalize Directory", () => {
+		assert.strictEqual(pathWin32.normalizeDir("C:/foo/bar"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\bar"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:/foo/bar/"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\bar\\"), "C:\\foo\\bar\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\bar\\.."), "C:\\foo\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\bar\\..\\"), "C:\\foo\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\..\\bar"), "C:\\bar\\");
+		assert.strictEqual(pathWin32.normalizeDir("C:\\foo\\..\\bar\\"), "C:\\bar\\");
+
+		assert.strictEqual(pathPosix.normalizeDir("\\home\\foo\\bar"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/bar"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalizeDir("\\home\\foo\\bar\\"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/bar/"), "/home/foo/bar/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/bar/.."), "/home/foo/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/bar/../"), "/home/foo/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/../bar"), "/home/bar/");
+		assert.strictEqual(pathPosix.normalizeDir("/home/foo/../bar/"), "/home/bar/");
+	});
+	test("Join", () => {
+		assert.strictEqual(pathWin32.join("C:/foo", "bar/baz.c"), "C:\\foo\\bar\\baz.c");
+		assert.strictEqual(pathWin32.join("C:\\foo", "bar\\baz.c"), "C:\\foo\\bar\\baz.c");
+		assert.strictEqual(pathWin32.join("C:\\foo\\", "\\bar\\baz.c"), "C:\\foo\\bar\\baz.c");
+		assert.strictEqual(pathWin32.join("C:\\Foo\\", "\\Bar\\baz.c"), "C:\\Foo\\Bar\\baz.c");
+
+		assert.strictEqual(pathPosix.join("\\home\\foo", "bar\\baz.c"), "/home/foo/bar/baz.c");
+		assert.strictEqual(pathPosix.join("/home/foo", "bar/baz.c"), "/home/foo/bar/baz.c");
+		assert.strictEqual(pathPosix.join("/home/foo/", "/bar/baz.c"), "/home/foo/bar/baz.c");
+		assert.strictEqual(pathPosix.join("/home/Foo/", "/Bar/baz.c"), "/home/Foo/Bar/baz.c");
+	});
+	test("Is Absolute Path", () => {
+		assert.strictEqual(pathWin32.isAbsolute("C:/foo/bar"), true);
+		assert.strictEqual(pathWin32.isAbsolute("C:\\foo\\bar"), true);
+		assert.strictEqual(pathWin32.isAbsolute("C:/foo/bar/"), true);
+		assert.strictEqual(pathWin32.isAbsolute("C:\\foo\\bar\\"), true);
+		assert.strictEqual(pathWin32.isAbsolute("C:\\foo\\..\\bar"), true);
+		assert.strictEqual(pathWin32.isAbsolute("C:\\foo\\..\\bar\\"), true);
+		assert.strictEqual(pathWin32.isAbsolute("foo/bar"), false);
+		assert.strictEqual(pathWin32.isAbsolute("foo\\bar"), false);
+		assert.strictEqual(pathWin32.isAbsolute("foo/bar/"), false);
+		assert.strictEqual(pathWin32.isAbsolute("foo\\bar\\"), false);
+
+		assert.strictEqual(pathPosix.isAbsolute("\\home\\foo\\bar"), true);
+		assert.strictEqual(pathPosix.isAbsolute("/home/foo/bar"), true);
+		assert.strictEqual(pathPosix.isAbsolute("\\home\\foo\\bar\\"), true);
+		assert.strictEqual(pathPosix.isAbsolute("/home/foo/bar/"), true);
+		assert.strictEqual(pathPosix.isAbsolute("/home/foo/../bar"), true);
+		assert.strictEqual(pathPosix.isAbsolute("/home/foo/../bar/"), true);
+		assert.strictEqual(pathPosix.isAbsolute("foo\\bar"), false);
+		assert.strictEqual(pathPosix.isAbsolute("foo/bar"), false);
+		assert.strictEqual(pathPosix.isAbsolute("foo\\bar\\"), false);
+		assert.strictEqual(pathPosix.isAbsolute("foo/bar/"), false);
+	});
+});

--- a/src/test/suite/source_file_map.test.ts
+++ b/src/test/suite/source_file_map.test.ts
@@ -1,0 +1,179 @@
+import * as assert from 'assert';
+import { PathKind, PathWin32, PathPosix } from "../../path_kind";
+import { SourceFileMap } from '../../source_file_map';
+
+suite("Source File Map", () => {
+	test("No Mappings", () => {
+		const fileMap: SourceFileMap = new SourceFileMap({});
+		const filePaths: string[] = [
+			"C:\\foo\\src\\bar.c",
+			"C:/foo/src/bar.c",
+			"/home/foo/src/bar.c",
+			"/home/Foo/src/bar.C"
+		];
+
+		filePaths.forEach(filePath => {
+			assert.strictEqual(fileMap.toLocalPath(filePath), filePath);
+			assert.strictEqual(fileMap.toRemotePath(filePath), filePath);
+		});
+	});
+	test("Native Path is Local Path", () => {
+		// Check native path before we override it in subsequent tests.
+		class NativeSourceFileMap extends SourceFileMap {
+			public getNativePathTest(): PathKind {
+				return this.getNativePath();
+			}
+		}
+		const fileMap: NativeSourceFileMap = new NativeSourceFileMap({});
+		if (process.platform == "win32")
+			assert.ok(fileMap.getNativePathTest() instanceof PathWin32);
+		else
+			assert.ok(fileMap.getNativePathTest() instanceof PathPosix);
+	});
+	suite("Local Paths are POSIX", () => {
+		class PosixSourceFileMap extends SourceFileMap {
+			protected getNativePath(): PathKind {
+				return PathPosix.getInstance();
+			}
+		}
+		test("Without Trailing Separator", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"C:\\foo": "/home/foo"});
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\src\\bar.c"), "/home/foo/src/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/src/bar.c"), "C:\\foo\\src\\bar.c");
+		});
+		test("With Trailing Separator", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"C:\\foo\\": "/home/foo/"});
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\src\\bar.c"), "/home/foo/src/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/src/bar.c"), "C:\\foo\\src\\bar.c");
+		});
+		test("Multiple Mappings", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({
+				"C:\\fooA\\": "/home/foo1/",
+				"C:\\fooB\\": "/home/foo2/",
+				"C:\\fooC\\": "/home/foo3/",
+			});
+			assert.strictEqual(fileMap.toLocalPath("C:\\fooA\\src\\bar.c"), "/home/foo1/src/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo1/src/bar.c"), "C:\\fooA\\src\\bar.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\fooB\\src\\bar.c"), "/home/foo2/src/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo2/src/bar.c"), "C:\\fooB\\src\\bar.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\fooC\\src\\bar.c"), "/home/foo3/src/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo3/src/bar.c"), "C:\\fooC\\src\\bar.c");
+		});
+		test("Case-Sensitive Paths", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"C:\\foo\\": "/home/Foo/"});
+			// Match
+			assert.strictEqual(fileMap.toRemotePath("/home/Foo/Src/Bar.c"), "C:\\foo\\Src\\Bar.c");
+			// No Match
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/Src/Bar.c"), "/home/foo/Src/Bar.c");
+		});
+		test("Case-Insensitive Paths", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"C:\\foo\\": "/home/Foo/"});
+			// Match
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\Src\\Bar.c"), "/home/Foo/Src/Bar.c");
+			assert.strictEqual(fileMap.toLocalPath("c:\\Foo\\Src\\Bar.c"), "/home/Foo/Src/Bar.c");
+		});
+		test("Local and Remote Path Types the Same", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"/home/foo": "/home/zoo"});
+			// Match
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/bar.c"), "/home/zoo/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/zoo/bar.c"), "/home/foo/bar.c");
+			// No Match
+			assert.strictEqual(fileMap.toLocalPath("/home/zoo/bar.c"), "/home/zoo/bar.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/bar.c"), "/home/foo/bar.c");
+		});
+		test("Non-Normalized Paths", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({"C:/foo/bar/baz/..": "/home/foo/../bar"});
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/bar/baz.c"), "/home/foo/bar/baz.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/bar/baz.c"), "C:\\foo\\bar\\baz.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/foo/../bar/baz.c"), "C:\\foo\\bar\\baz.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\bar\\baz\\zoo.c"), "/home/bar/baz/zoo.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\bar\\baz\\..\\zoo.c"), "/home/bar/zoo.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\bar\\baz.c"), "/home/bar/baz.c");
+		});
+		test("Overlapping Paths", () => {
+			const fileMap: PosixSourceFileMap = new PosixSourceFileMap({
+				"C:\\foo":      "/home/foo1",
+				"C:\\foo\\bar": "/home/foo2",
+				"C:\\zoo1":     "/home/zoo",
+				"C:\\zoo2":     "/home/zoo/bar"
+			});
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\baz.c"), "/home/foo1/baz.c");
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\bar\\baz.c"), "/home/foo2/baz.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/zoo/baz.c"), "C:\\zoo1\\baz.c");
+			assert.strictEqual(fileMap.toRemotePath("/home/zoo/bar/baz.c"), "C:\\zoo2\\baz.c");
+		});
+	});
+	suite("Local Paths are Win32", () => {
+		class Win32SourceFileMap extends SourceFileMap {
+			protected getNativePath(): PathKind {
+				return PathWin32.getInstance();
+			}
+		}
+		test("Without Trailing Separator", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"/home/foo": "C:\\foo"});
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/src/bar.c"), "C:\\foo\\src\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\src\\bar.c"), "/home/foo/src/bar.c");
+		});
+		test("With Trailing Separator", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"/home/foo/": "C:\\foo\\"});
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/src/bar.c"), "C:\\foo\\src\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\src\\bar.c"), "/home/foo/src/bar.c");
+		});
+		test("Multiple Mappings", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({
+				"/home/foo1/": "C:\\fooA\\",
+				"/home/foo2/": "C:\\fooB\\",
+				"/home/foo3/": "C:\\fooC\\",
+			});
+			assert.strictEqual(fileMap.toLocalPath("/home/foo1/src/bar.c"), "C:\\fooA\\src\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\fooA\\src\\bar.c"), "/home/foo1/src/bar.c");
+			assert.strictEqual(fileMap.toLocalPath("/home/foo2/src/bar.c"), "C:\\fooB\\src\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\fooB\\src\\bar.c"), "/home/foo2/src/bar.c");
+			assert.strictEqual(fileMap.toLocalPath("/home/foo3/src/bar.c"), "C:\\fooC\\src\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\fooC\\src\\bar.c"), "/home/foo3/src/bar.c");
+		});
+		test("Case-Sensitive Paths", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"/home/Foo/": "C:\\foo\\"});
+			// Match
+			assert.strictEqual(fileMap.toLocalPath("/home/Foo/Src/Bar.c"), "C:\\foo\\Src\\Bar.c");
+			// No Match
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/Src/Bar.c"), "/home/foo/Src/Bar.c");
+		});
+		test("Case-Insensitive Paths", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"/home/Foo/": "C:\\foo\\"});
+			// Match
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\Src\\Bar.c"), "/home/Foo/Src/Bar.c");
+			assert.strictEqual(fileMap.toRemotePath("c:\\Foo\\Src\\Bar.c"), "/home/Foo/Src/Bar.c");
+		});
+		test("Local and Remote Path Types the Same", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"C:\\foo": "C:\\zoo"});
+			// Match
+			assert.strictEqual(fileMap.toLocalPath("C:\\foo\\bar.c"), "C:\\zoo\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\zoo\\bar.c"), "C:\\foo\\bar.c");
+			// No Match
+			assert.strictEqual(fileMap.toLocalPath("C:\\zoo\\bar.c"), "C:\\zoo\\bar.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\bar.c"), "C:\\foo\\bar.c");
+		});
+		test("Non-Normalized Paths", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({"/home/foo/../bar": "C:/foo/bar/baz/.."});
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/bar/baz.c"), "/home/foo/bar/baz.c");
+			assert.strictEqual(fileMap.toLocalPath("/home/bar/baz.c"), "C:\\foo\\bar\\baz.c");
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/../bar/baz.c"), "C:\\foo\\bar\\baz.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\bar\\baz\\zoo.c"), "/home/bar/baz/zoo.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\bar\\baz\\..\\zoo.c"), "/home/bar/zoo.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\foo\\bar\\baz.c"), "/home/bar/baz.c");
+		});
+		test("Overlapping Paths", () => {
+			const fileMap: Win32SourceFileMap = new Win32SourceFileMap({
+				"/home/foo":     "C:\\foo1",
+				"/home/foo/bar": "C:\\foo2",
+				"/home/zoo1":    "C:\\zoo",
+				"/home/zoo2":    "C:\\zoo\\bar"
+			});
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/baz.c"), "C:\\foo1\\baz.c");
+			assert.strictEqual(fileMap.toLocalPath("/home/foo/bar/baz.c"), "C:\\foo2\\baz.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\zoo\\baz.c"), "/home/zoo1/baz.c");
+			assert.strictEqual(fileMap.toRemotePath("C:\\zoo\\bar\\baz.c"), "/home/zoo2/baz.c");
+		});
+	});
+});


### PR DESCRIPTION
Fixes #346.

For SSH path mapping, the unmapped portion of the path will retain its
case, so that mapping to file systems which are case sensitive will work
as expected.  Furthermore, additional functionality has been added, such
as proper detection and handling of overlapping paths.

Additionally, the source file mapping and path handling functionality
has been moved to their own files to improve cohesion and better support
unit testing.  Unit tests have been added for source file mapping as
well as path functionality.