### PR TITLE
apply sourceFileMap for "go to cursor", fixes #332

### DIFF
--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -7,6 +7,7 @@ import * as net from "net";
 import * as fs from "fs";
 import * as path from "path";
 import { Client } from "ssh2";
+import { MI2DebugSession } from "../../mibase";
 
 export function escape(str: string) {
 	return str.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
@@ -25,7 +26,7 @@ function couldBeOutput(line: string) {
 const trace = false;
 
 export class MI2 extends EventEmitter implements IBackend {
-	constructor(public application: string, public preargs: string[], public extraargs: string[], procEnv: any, public extraCommands: string[] = []) {
+	constructor(private dbg_session: MI2DebugSession, public application: string, public preargs: string[], public extraargs: string[], procEnv: any, public extraCommands: string[] = []) {
 		super();
 
 		if (procEnv) {
@@ -538,6 +539,7 @@ export class MI2 extends EventEmitter implements IBackend {
 	goto(filename: string, line: number): Thenable<Boolean> {
 		if (trace)
 			this.log("stderr", "goto");
+		filename = this.dbg_session.apply_sourceFileMapping(filename);
 		return new Promise((resolve, reject) => {
 			const target: string = '"' + (filename ? escape(filename) + ":" : "") + line + '"';
 			this.sendCommand("break-insert -t " + target).then(() => {

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -53,7 +53,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.miDebugger = new MI2(this, args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
 		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
@@ -102,7 +102,7 @@ class GDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2(args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
+		this.miDebugger = new MI2(this, args.gdbpath || "gdb", ["-q", "--interpreter=mi2"], args.debugger_args, args.env);
 		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -48,7 +48,7 @@ class LLDBDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
+		this.miDebugger = new MI2_LLDB(this, args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
 		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;
@@ -93,7 +93,7 @@ class LLDBDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2_LLDB(args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
+		this.miDebugger = new MI2_LLDB(this, args.lldbmipath || "lldb-mi", [], args.debugger_args, args.env);
 		this.setPathSubstitutions(args.pathSubstitutions);
 		this.initDebugger();
 		this.quit = false;

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -50,7 +50,7 @@ class MagoDebugSession extends MI2DebugSession {
 	}
 
 	protected launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
-		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", ["-q"], args.debugger_args, args.env);
+		this.miDebugger = new MI2_Mago(this, args.magomipath || "mago-mi", ["-q"], args.debugger_args, args.env);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = false;
@@ -71,7 +71,7 @@ class MagoDebugSession extends MI2DebugSession {
 	}
 
 	protected attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
-		this.miDebugger = new MI2_Mago(args.magomipath || "mago-mi", [], args.debugger_args, args.env);
+		this.miDebugger = new MI2_Mago(this, args.magomipath || "mago-mi", [], args.debugger_args, args.env);
 		this.initDebugger();
 		this.quit = false;
 		this.attached = true;

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -226,6 +226,14 @@ export class MI2DebugSession extends DebugSession {
 		});
 	}
 
+	apply_sourceFileMapping(path: string): string {
+		if (this.isSSH) {
+			// convert local path to ssh path
+			return this.sourceFileMap.toRemotePath(path);
+		}
+		return path;
+	}
+
 	protected setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): void {
 		this.miDebugger.clearBreakPoints(args.source.path).then(() => {
 			let path = args.source.path;


### PR DESCRIPTION
fix #332 by passing MI2 an instance of MI2DebugSession

Note: for reasons I do not know I actually don't reach that code any more!
While the code `response.body.supportsGotoTargetsRequest = true;` is executed and the capability is sent to the debug client - it never gets executed. Instead a breakpoint setting and target continuation is requested and done by code-debug - which is really bad for different reasons including: the breakpoint persists [it is not temporary], the code does a lot more unnecessary stuff and as a side effect: the bug was not reproducible any more because the conversion works fine with the breakpoints already.

I still would like to see a code review - especially as I wasn't sure how to handle it best:

* pass MI2 an instance of MI2DebugSession (as done)
* pass MI2DebugSession to MI2
* pass a callable to do the conversion from MI2DebugSession to MI2 (sounds "cleaner", but I don't know yet how to do it)
* use messaging (I guess that would be bad because we want that do be done directly)

Also, if this PR is merged, a follow-up check should be done if there are more reasonably things to directly call from one class in the other.