### PR TITLE
Enable breakpoints for RISC-V assembly

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
 			},
 			{
 				"language": "zig"
+			},
+			{
+				"language": "riscv"
 			}
 		],
 		"debuggers": [
@@ -129,7 +132,8 @@
 					"vala",
 					"crystal",
 					"kotlin",
-					"zig"
+					"zig",
+					"riscv"
 				],
 				"variables": {
 					"FileBasenameNoExt": "code-debug.getFileBasenameNoExt",
@@ -595,7 +599,8 @@
 					"vala",
 					"crystal",
 					"kotlin",
-					"zig"
+					"zig",
+					"riscv"
 				],
 				"variables": {
 					"FileBasenameNoExt": "code-debug.getFileBasenameNoExt",


### PR DESCRIPTION
Add support for RISC-V assembly debugging. Language id is from [RISC-V Assembly](https://marketplace.visualstudio.com/items?itemName=zhwu95.riscv).