### PR TITLE
Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Versioning].
 
 ### Added
 
+- fix gdb check error when debug beginning ([@henryriley0])
+- fix implicitly type error in log message when build vsix ([@henryriley0])
 - check for configured debugger before start to provide a nicer error message
   ([@GitMensch])
 
@@ -242,6 +244,7 @@ Versioning].
 [@gentoo90]: https://github.com/gentoo90
 [@gitmensch]: https://github.com/GitMensch
 [@haronk]: https://github.com/HaronK
+[@henryriley0]: https://github.com/HenryRiley0
 [@jelleroets]: https://github.com/JelleRoets
 [@karljs]: https://github.com/karljs
 [@kvinwang]: https://github.com/kvinwang

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -33,7 +33,7 @@ class LogMessage {
 	protected logReplaceTest = /{([^}]*)}/g;
 	public logMsgBrkList: Breakpoint[] = [];
 
-	logMsgOutput(record){
+	logMsgOutput(record:any){
 		if ((record.type === 'console')) {
 			if(record.content.startsWith("$")){
 				const content = record.content;
@@ -54,7 +54,7 @@ class LogMessage {
 		}
 	}
 
-	logMsgProcess(parsed){
+	logMsgProcess(parsed:any){
 		this.logMsgBrkList.forEach((brk)=>{
 			if(parsed.outOfBandRecord[0].output[0][1] == "breakpoint-hit" && parsed.outOfBandRecord[0].output[2][1] == brk.id){
 				this.logMsgVar = brk?.logMessage;
@@ -626,7 +626,7 @@ export class MI2 extends EventEmitter implements IBackend {
 		return this.sendCommand("break-condition " + bkptNum + " " + condition);
 	}
 
-	setLogPoint(bkptNum, command): Thenable<any> {
+	setLogPoint(bkptNum:number, command:string): Thenable<any> {
 		const regex = /{([a-z0-9A-Z-_\.\>\&\*\[\]]*)}/gm;
 		let m:RegExpExecArray;
 		let commands:string = "";

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -55,7 +55,7 @@ class GDBDebugSession extends MI2DebugSession {
 
 	protected override launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		const dbgCommand = args.gdbpath || "gdb";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}
@@ -101,7 +101,7 @@ class GDBDebugSession extends MI2DebugSession {
 
 	protected override attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
 		const dbgCommand = args.gdbpath || "gdb";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -49,7 +49,7 @@ class LLDBDebugSession extends MI2DebugSession {
 
 	protected override launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		const dbgCommand = args.lldbmipath || "lldb-mi";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}
@@ -95,7 +95,7 @@ class LLDBDebugSession extends MI2DebugSession {
 
 	protected override attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
 		const dbgCommand = args.lldbmipath || "lldb-mi";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -51,7 +51,7 @@ class MagoDebugSession extends MI2DebugSession {
 
 	protected override launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments): void {
 		const dbgCommand = args.magomipath || "mago-mi";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}
@@ -75,7 +75,7 @@ class MagoDebugSession extends MI2DebugSession {
 
 	protected override attachRequest(response: DebugProtocol.AttachResponse, args: AttachRequestArguments): void {
 		const dbgCommand = args.magomipath || "mago-mi";
-		if (this.checkCommand(dbgCommand)) {
+		if (!this.checkCommand(dbgCommand)) {
 			this.sendErrorResponse(response, 104, `Configured debugger ${dbgCommand} not found.`);
 			return;
 		}


### PR DESCRIPTION
1.fix  implicitly type error of LogMessage
2.fix gdb check error, checkCommand success should not warning "Configured debugger ${dbgCommand} not found"  

```
	protected checkCommand(debuggerName: string): boolean {
		try {
			const command = process.platform === 'win32' ? 'where' : 'command -v';
			execSync(`${command} ${debuggerName}`, { stdio: 'ignore' });
			return true;
		} catch (error) {
			return false;
		}
	}
```