### PR TITLE
fix static variable not showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning].
 
 ### Added
 
+- add static variable support ([@henryriley0])
 - fix gdb check error when debug beginning ([@henryriley0])
 - fix implicitly type error in log message when build vsix ([@henryriley0])
 - check for configured debugger before start to provide a nicer error message

--- a/src/backend/gdb_expansion.ts
+++ b/src/backend/gdb_expansion.ts
@@ -197,6 +197,7 @@ export function expandValue(variableCreate: (arg: VariableObject | string, optio
 
 	parseResult = (pushToStack: boolean = false) => {
 		value = value.trim();
+		value = value.replace(/^static /, "");
 		const variableMatch = resultRegex.exec(value);
 		if (!variableMatch)
 			return undefined;


### PR DESCRIPTION
the static member of Class People does not show 
Log

```
GDB -> App: {"token":17,"outOfBandRecord":[],"resultRecords":{"resultClass":"done","results":[["value","{stu = {name = 0x0, age = 0, score = 0}, pt = {name = 0x0, learntime = 0}, static borth = 10}"]]}}
-gdb-exit
```
![image](https://github.com/user-attachments/assets/924dcdf8-a194-426a-baec-4aac200bc51d)

does not show:
![2](https://github.com/user-attachments/assets/6eb7eea2-fe44-4067-99e9-210d3baf3811)

fixed:
![fixed](https://github.com/user-attachments/assets/936e0acc-abd3-4e34-8053-768367244191)