### PR TITLE
Support GDB frame filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versioning].
 - fix implicitly type error in log message when build vsix ([@henryriley0])
 - check for configured debugger before start to provide a nicer error message
   ([@GitMensch])
+- New `frameFilters` option for GDB that allows using custom frame filters,
+  enabled by default ([@JacquesLucke])
 
 ## [0.27.0] - 2024-02-07
 
@@ -245,6 +247,7 @@ Versioning].
 [@gitmensch]: https://github.com/GitMensch
 [@haronk]: https://github.com/HaronK
 [@henryriley0]: https://github.com/HenryRiley0
+[@jacqueslucke]: https://github.com/JacquesLucke
 [@jelleroets]: https://github.com/JelleRoets
 [@karljs]: https://github.com/karljs
 [@kvinwang]: https://github.com/kvinwang

--- a/package.json
+++ b/package.json
@@ -194,6 +194,11 @@
 									"prettyPrinters"
 								]
 							},
+							"frameFilters": {
+								"type": "boolean",
+								"description": "Use frame filters registered in GDB",
+								"default": true
+							},
 							"printCalls": {
 								"type": "boolean",
 								"description": "Prints all GDB calls to the console",
@@ -321,6 +326,11 @@
 									"parseText",
 									"prettyPrinters"
 								]
+							},
+							"frameFilters": {
+								"type": "boolean",
+								"description": "Use frame filters registered in GDB",
+								"default": true
 							},
 							"printCalls": {
 								"type": "boolean",

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -17,6 +17,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	stopAtEntry: boolean | string;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
+	frameFilters: boolean;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -35,6 +36,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	stopAtEntry: boolean | string;
 	ssh: SSHArguments;
 	valuesFormatting: ValuesFormattingMode;
+	frameFilters: boolean;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
 }
@@ -69,6 +71,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.started = false;
 		this.crashed = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
+		this.miDebugger.frameFilters = !!args.frameFilters;
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;
@@ -113,6 +116,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.initialRunCommand = args.stopAtConnect ? RunCommand.NONE : RunCommand.CONTINUE;
 		this.isSSH = false;
 		this.setValuesFormattingMode(args.valuesFormatting);
+		this.miDebugger.frameFilters = !!args.frameFilters;
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -320,7 +320,7 @@ export class MI2DebugSession extends DebugSession {
 
 				ret.push(new StackFrame(
 					this.threadAndLevelToFrameId(args.threadId, element.level),
-					element.function + "@" + element.address,
+					element.function + (element.address ? "@" + element.address : ""),
 					source,
 					element.line,
 					0));


### PR DESCRIPTION
### Overview

This adds a new `frameFilters` option for GDB. When enabled, `enable-frame-filters` is passed to GDB which will run [frame filters](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Frame-Filter-API.html) before they are passed to the extension. 

By default, the option is off to avoid regressions in existing setups. If no issues are found over time, it may make sense to enable them by default. If a user has custom frame filters, it probably makes sense that they should also show up in vscode. It's still always possible to access the full backtrace in the `Debug Console`.

### Motivation

I want to use these filters to simplify debugging when working on Blender. They can greatly simplify the backtraces making them easier to scan in the majority of use-cases. See the example below which shows the original and simplified backtrace. Note that this is still a fairly simple case and the backtrace may become way deeper in some situations.

Before:
![image](https://github.com/user-attachments/assets/83524440-35ba-4321-8beb-82cffc5627e7)
After:
![image](https://github.com/user-attachments/assets/d6e194b5-b161-497f-bb30-920088077939)

### Details

For some reason, GDB does not provide the `@frame.fullname` property for stack frames when frame filters are used. However, in my case `@frame.file` was provided and contained the absolute path too. So this is now used as a fallback.

Previously, the stack frame name was always `function_name@address`. However, with frame filters, the address might not always be known. I changed it so that the `@address` part is omitted when the address is unknown.
