### PR TITLE
prevent error in evaluateRequest when a variable is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning].
   ([@GitMensch])
 - New `frameFilters` option for GDB that allows using custom frame filters,
   enabled by default ([@JacquesLucke])
+- Suppress error for hover as the user may just play with the mouse ([@oltolm]).
 
 ## [0.27.0] - 2024-02-07
 

--- a/src/mibase.ts
+++ b/src/mibase.ts
@@ -715,7 +715,12 @@ export class MI2DebugSession extends DebugSession {
 				};
 				this.sendResponse(response);
 			}, msg => {
-				this.sendErrorResponse(response, 7, msg.toString());
+				if (args.context == "hover") {
+					// suppress error for hover as the user may just play with the mouse
+					this.sendResponse(response);
+				} else {
+					this.sendErrorResponse(response, 7, msg.toString());
+				}
 			});
 		} else {
 			this.miDebugger.sendUserInput(args.expression, threadId, level).then(output => {


### PR DESCRIPTION
This prevents the error message when a variable can not be found. Fixes https://github.com/WebFreak001/code-debug/issues/429.