### PR TITLE
Add `registerLimit` config option to specify the registers to list in Registers view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning].
   enabled by default ([@JacquesLucke])
 - Suppress error for hover as the user may just play with the mouse ([@oltolm]).
 - solve the problem of failed parsing of containers ([@henryriley0])
+- Resolves #421 - Added `registerLimit` option to specify the registers to display to avoid corrupting the whole registers view - PR #444 ([@chenzhiy2001])
 
 ## [0.27.0] - 2024-02-07
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ that location prior to continuing execution.  Note that stopping at the entry po
 attach configuration assumes that the entry point has not yet been entered at the time of
 attach, otherwise this will have no affect.
 
+There is a Registers view in the VARIABLES view. As we fetch all registers at once, there can
+be cases where a register that cannot be fetched causes the entire register request to fail,
+corrupting the entire Registers output. If this happens, you might need to set the
+`registerLimit` option to specify which registers you want the debugger to fetch
+automatically.
+
+For example, to display only registers `rax` and `rip` in an x64 debug session, send the
+command `-data-list-register-names` in the debug console of an active x64 debug session.
+You will then receive a response containing an array starting with `["rax","rbx" ...]`.
+In this array, the index of `rax` is 0 and `rip` is 16, so set the option as
+`"registerLimit": "0 16"`. If you find the response text hard to navigate, you can paste
+it into a browser's developer tools console and press enter to get an expandable response
+object with array elements' indices explicitly displayed.
+
 ### Attaching to existing processes
 
 Attaching to existing processes currently only works by specifying the PID in the

--- a/package.json
+++ b/package.json
@@ -299,6 +299,11 @@
 										"description": "Content will be executed on the SSH host before the debugger call."
 									}
 								}
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					},
@@ -468,6 +473,11 @@
 										"description": "Content will be executed on the SSH host before the debugger call."
 									}
 								}
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					}
@@ -766,6 +776,11 @@
 										"description": "Content will be executed on the SSH host before the debugger call."
 									}
 								}
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					},
@@ -846,6 +861,11 @@
 								],
 								"description": "Whether debugger should stop at application entry point",
 								"default": false
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					}
@@ -992,6 +1012,11 @@
 								"type": "array",
 								"description": "mago commands to run when starting to debug",
 								"default": []
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					},
@@ -1057,6 +1082,11 @@
 								"type": "boolean",
 								"description": "Whether debugger should stop after connecting to target",
 								"default": false
+							},
+							"registerLimit": {
+								"type": "string",
+								"description": "List of numbers specifying the registers to display. An empty string indicates that the contents of all the registers must be returned.",
+								"default": ""
 							}
 						}
 					}

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -883,7 +883,7 @@ export class MI2 extends EventEmitter implements IBackend {
 	async getRegisterValues(): Promise<RegisterValue[]> {
 		if (trace)
 			this.log("stderr", "getRegisterValues");
-		const result = await this.sendCommand("data-list-register-values N");
+		const result = await this.sendCommand("data-list-register-values --skip-unavailable N " + this.registerLimit);
 		const nodes = result.result('register-values');
 		if (!Array.isArray(nodes)) {
 			throw new Error('Failed to retrieve register values.');
@@ -1024,6 +1024,7 @@ export class MI2 extends EventEmitter implements IBackend {
 	debugOutput: boolean;
 	features: string[];
 	public procEnv: any;
+	public registerLimit: string;
 	protected isSSH: boolean;
 	protected sshReady: boolean;
 	protected currentToken: number = 1;

--- a/src/gdb.ts
+++ b/src/gdb.ts
@@ -20,6 +20,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	frameFilters: boolean;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -39,6 +40,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	frameFilters: boolean;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 class GDBDebugSession extends MI2DebugSession {
@@ -75,6 +77,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;
@@ -120,6 +123,7 @@ class GDBDebugSession extends MI2DebugSession {
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;

--- a/src/lldb.ts
+++ b/src/lldb.ts
@@ -18,6 +18,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -34,6 +35,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 class LLDBDebugSession extends MI2DebugSession {
@@ -66,6 +68,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		if (args.ssh !== undefined) {
 			if (args.ssh.forwardX11 === undefined)
 				args.ssh.forwardX11 = true;
@@ -110,6 +113,7 @@ class LLDBDebugSession extends MI2DebugSession {
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
 		this.stopAtEntry = args.stopAtEntry;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		this.miDebugger.attach(args.cwd, args.executable, args.target, args.autorun || []).then(() => {
 			this.sendResponse(response);
 		}, err => {

--- a/src/mago.ts
+++ b/src/mago.ts
@@ -15,6 +15,7 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 export interface AttachRequestArguments extends DebugProtocol.AttachRequestArguments {
@@ -29,6 +30,7 @@ export interface AttachRequestArguments extends DebugProtocol.AttachRequestArgum
 	valuesFormatting: ValuesFormattingMode;
 	printCalls: boolean;
 	showDevDebugOutput: boolean;
+	registerLimit: string;
 }
 
 class MagoDebugSession extends MI2DebugSession {
@@ -66,6 +68,7 @@ class MagoDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		this.miDebugger.load(args.cwd, args.target, args.arguments, undefined, args.autorun || []).then(() => {
 			this.sendResponse(response);
 		}, err => {
@@ -88,6 +91,7 @@ class MagoDebugSession extends MI2DebugSession {
 		this.setValuesFormattingMode(args.valuesFormatting);
 		this.miDebugger.printCalls = !!args.printCalls;
 		this.miDebugger.debugOutput = !!args.showDevDebugOutput;
+		this.miDebugger.registerLimit = args.registerLimit ?? "";
 		this.miDebugger.attach(args.cwd, args.executable, args.target, args.autorun || []).then(() => {
 			this.sendResponse(response);
 		}, err => {


### PR DESCRIPTION
In cases like #421, fetching unfetchable registers can corrupt the whole Registers view. 

So I added `registerLimit` config option to let users specify what registers they want the debugger to automatically fetch, thus avoiding the issue.