### PR TITLE
Support unix-based X11 server connections as well as TCP-based ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,12 +281,12 @@
 											"number",
 											"string"
 										],
-										"description": "Port to redirect X11 data to (by default port = display + 6000)",
+										"description": "TCP port to redirect X11 data to (by default port = display + 6000); raw display number for unix domain connection",
 										"default": 6000
 									},
 									"x11host": {
 										"type": "string",
-										"description": "Hostname/ip to redirect X11 data to",
+										"description": "Hostname/ip to redirect X11 data to; empty string for a unix domain connection",
 										"default": "localhost"
 									},
 									"remotex11screen": {
@@ -455,12 +455,12 @@
 											"number",
 											"string"
 										],
-										"description": "Port to redirect X11 data to (by default port = display + 6000)",
+										"description": "TCP port to redirect X11 data to (by default port = display + 6000); raw display number for unix domain connection",
 										"default": 6000
 									},
 									"x11host": {
 										"type": "string",
-										"description": "Hostname/ip to redirect X11 data to",
+										"description": "Hostname/ip to redirect X11 data to; empty string for a unix domain connection",
 										"default": "localhost"
 									},
 									"remotex11screen": {
@@ -755,7 +755,7 @@
 									},
 									"x11host": {
 										"type": "string",
-										"description": "Hostname/ip to redirect X11 data to",
+										"description": "Hostname/ip to redirect X11 data to; empty string for a unix domain connection",
 										"default": "localhost"
 									},
 									"x11port": {
@@ -763,7 +763,7 @@
 											"number",
 											"string"
 										],
-										"description": "Port to redirect X11 data to (by default port = display + 6000)",
+										"description": "TCP port to redirect X11 data to (by default port = display + 6000); raw display number for unix domain connection",
 										"default": 6000
 									},
 									"remotex11screen": {

--- a/src/backend/mi2/mi2.ts
+++ b/src/backend/mi2/mi2.ts
@@ -155,7 +155,10 @@ export class MI2 extends EventEmitter implements IBackend {
 						const xclientsock = accept();
 						xclientsock.pipe(xserversock).pipe(xclientsock);
 					});
-					xserversock.connect(args.x11port, args.x11host);
+					if (args.x11host !== "")
+						xserversock.connect(args.x11port, args.x11host);
+					else
+						xserversock.connect(`/tmp/.X11-unix/X${args.x11port}`);
 				});
 			}
 


### PR DESCRIPTION
Typically, on unix systems, local X11 is connected through the socket `/tmp/.X11-unix/X0`, as indicated by the missing host name part in `DISPLAY=:0` or `DISPLAY=:0.0`. WSLg (the X11 implementation provided with WSL in Microsoft Windows) does not listen on the TCP socket localhost:6000, but on the Unix socket only.

So this pull request enables SSH X11 forwarding to connect to the unix domain socket if the X server host name is set to the empty string.